### PR TITLE
Reintroduce 1-minute delay shutdown.

### DIFF
--- a/roles/rebooted/tasks/main.yml
+++ b/roles/rebooted/tasks/main.yml
@@ -27,14 +27,20 @@
   register: pre_result
   changed_when: false
 
-- debug: msg="Pre-reboot uptime is {{ pre_result.stdout }}s and shutdown_timeout is {{ shutdown_timeout }}s"
+- debug: msg="Pre-reboot uptime is {{ pre_result.stdout }}s"
 
 # Note: For ansible 1.8.x this works well
 - name: Reboot System
-  command: shutdown -r now "Atomic host updated"
+  command: shutdown -r 1
   async: 0
   poll: 0
   ignore_errors: true
+
+- name: Wait for reboot
+  pause:
+  args:
+    minutes: 1
+  delegate_to: 127.0.0.1
 
 - name: System has booted back up
   local_action: wait_for host={{ inventory_hostname }}
@@ -49,7 +55,9 @@
   register: post_result
   changed_when: false
 
+- debug: msg="Post-reboot uptime is {{ post_result.stdout }}s"
+
 - fail:
   args:
     msg: "Post-reboot uptime {{ post_result.stdout }}s longer than pre-reboot uptime {{ pre_result.stdout }}s"
-  when: "{{ post_result.stdout | int }} >= {{ pre_result.stdout | int }}"
+  when: "{{ post_result.stdout }} >= {{ pre_result.stdout }}"


### PR DESCRIPTION
Depending on state of system, it may not always reboot.  Performing
the operation asynchronsly with the minumum delay was found to
avoid this problem.

Signed-off-by: Chris Evich <cevich@redhat.com>