### PR TITLE
Devel

### DIFF
--- a/roles/autotested/tasks/configure_control.yml
+++ b/roles/autotested/tasks/configure_control.yml
@@ -1,4 +1,7 @@
 ---
+- debug: var=autotest_docker.timeout
+  when: autotest_docker.timeout is defined
+
 - name: Control timeout set
   lineinfile:
   args:
@@ -7,8 +10,7 @@
     follow: True
     line: "\\1 {{ autotest_docker.timeout }}"
     regexp: "^(TIMEOUT\\s*=\\s*).*$"
-  when: autotest_docker.timeout is defined and
-        autotest_docker.timeout is number
+  when: autotest_docker.timeout is defined
 
 - name: Config_custom_control string is set
   set_fact:

--- a/roles/autotested/tasks/test_image_fqin.yml
+++ b/roles/autotested/tasks/test_image_fqin.yml
@@ -72,3 +72,22 @@
         (autotest_docker.test_image.build_url is defined and
          autotest_docker.test_image.build_url != None and
          autotest_docker.test_image.build_url != "")
+
+- name: Test image has been pulled
+  command: /usr/bin/docker pull
+           {{ test_image_fqin }}
+  when: test_image_fqin is defined and
+        autotest_docker.test_image is defined and
+        docker_inspect_result|failed and
+        (autotest_docker.test_image.build_url is not defined or
+         autotest_docker.test_image.build_url == None or
+         autotest_docker.test_image.build_url == "")
+
+- name: Docker images output is captured
+  command: /usr/bin/docker images --all
+  register: docker_images_output
+  ignore_errors: True
+  changed_when: false
+
+- debug: var=docker_images_output
+  when: docker_images_output is defined


### PR DESCRIPTION
Fix timeout not being set, and pre-pull the test image before starting Docker Autotest.