### PR TITLE
Disable restart the docker daemon using alternate options

### DIFF
--- a/roles/autotested/defaults/main.yml
+++ b/roles/autotested/defaults/main.yml
@@ -6,6 +6,9 @@ docker_autotest_cache_dir: "{{ workspace }}/cache/"
 # Remote directory where Autotest will be installed
 autotest_dest_dir: "/var/lib/autotest"
 
+# Timeout in seconds to rewrite into control-file, will be divided
+# equally among all subtests.
+docker_autotest_timeout: 3600
 
 docker_autotest:
 
@@ -20,10 +23,6 @@ docker_autotest:
         # Build this image from url, tagged as above name.
         # Leave empty to pull test image instead.
         build_url:
-
-    # Ultimate timeout in seconds for all subtests to run
-    # (in seconds).
-    timeout: 300
 
     # List of subtests to include, empty to use defaults
     # (runs _all_ specified by subthings, below).

--- a/roles/autotested/tasks/configure_control.yml
+++ b/roles/autotested/tasks/configure_control.yml
@@ -8,7 +8,7 @@
     backrefs: true
     dest: "{{ autotest_docker_path }}/control"
     follow: True
-    line: "\\1 {{ docker_autotest.timeout }}"
+    line: "\\1 {{ docker_autotest_timeout }}"
     regexp: "^(TIMEOUT\\s*=\\s*).*$"
   when: docker_autotest.timeout is defined
 

--- a/roles/autotested/tasks/configure_defaults.yml
+++ b/roles/autotested/tasks/configure_defaults.yml
@@ -31,39 +31,17 @@
   command: systemctl is-active docker
   when: defaults_needed
 
-- name: Systemctl shows docker MainPID
-  shell: systemctl show docker --property=MainPID | head -1 | cut -d= -f2
-  register: docker_main_pid_cmd
-  when: defaults_needed
-
-- name: Docker daemon cmdline file is defined
-  set_fact:
-    dd_proc_cmdline: /proc/{{ docker_main_pid_cmd.stdout }}/cmdline
-  when: defaults_needed
-
-- name: Docker daemon cmdline file exists
-  stat:
-  args:
-    path: "{{ dd_proc_cmdline }}"
-  register: dd_cmdline
-  when: defaults_needed
-
-# Cat exits 0 even if file doesn't exist
-- fail:
-  when: defaults_needed and not dd_cmdline.stat.exists
-
-- name: Docker daemon options are known
-  shell: "cat {{ dd_proc_cmdline }} | tr '\\000' ',' | tr -c -d [:print:] | cut -d, -f 2-"
-  register: cat_pid_cmd
-  when: defaults_needed
-
+# TODO: Cooperate with systemd and newer docker versions
+#       https://github.com/autotest/autotest-docker/issues/612
+# workaround for now, causing an error if any subtests attempt to use
+# dockertest.docker_daemon.start()
 - name: Defaults daemon_options is configured
   ini_file:
   args:
     dest: "{{ config_custom_defaults }}"
     option: daemon_options
     section: DEFAULTS
-    value: "{{ cat_pid_cmd.stdout_lines[0] }}"
+    value: "##### Not Supported #####"
   when: defaults_needed
 
 - name: Don't check Autotest version


### PR DESCRIPTION
This approach worked at one point, but is poorly designed.  These
tasks are to support docker-autotest subtests which no longer exist.
The underlying calls also need to be reimplemented as per:

https://github.com/autotest/autotest-docker/issues/612

Signed-off-by: Chris Evich <cevich@redhat.com>