### PR TITLE
Fix default adept_job and missing fedoratomic peon

### DIFF
--- a/files/variables.yml
+++ b/files/variables.yml
@@ -9,4 +9,4 @@ adept_cloud_type: 'openstack'
 # here for play-scoping purposes
 
 # machine-consumable value to help distinguish among different runs
-adept_job: '{{ adept_job | default(lookup("file", "/proc/uptime") | to_uuid) }}'
+adept_job: '{{ lookup("file", "/proc/uptime") | to_uuid }}'

--- a/vars/peons.yml
+++ b/vars/peons.yml
@@ -27,6 +27,9 @@ peons:
       defaults: "rhelatomic"
 
     - name: "fedora"
+      defaults: "fedora"
+
+    - name: "fedoratomic"
       defaults: "fedoratomic"
 
 # List of peon attribute name(s) to compute matrix product.


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>