### PR TITLE
Fix Autotest/Docker Autotest cache clash

### DIFF
--- a/roles/autotested/tasks/main.yml
+++ b/roles/autotested/tasks/main.yml
@@ -32,6 +32,11 @@
     path: "{{ autotest_dest_dir }}/RELEASE-VERSION"
     state: absent
 
+- name: Bundled Docker Autotest directory is removed
+  file:
+    path: "{{ autotest_docker_path }}"
+    state: absent
+
 - name: Cached Docker Autotest is copied
   synchronize:
     dest: "{{ autotest_docker_path }}"


### PR DESCRIPTION
The autotested role first transfers a copy of the autotest repository to
the test VM.  If recursive submodules were used to clone that repo,
it will include a (likely very) old version of docker autotest.  Later,
when the cached (modern) docker-autotest is also transfered, it will end
up with bits that have long since been removed.

Fix this by first removing the docker autotest path before doing the
cache copy.

Signed-off-by: Chris Evich <cevich@redhat.com>