### PR TITLE
Fix build/https_file on RHEL* VMs

### DIFF
--- a/roles/autotested/templates/subtests.ini.j2
+++ b/roles/autotested/templates/subtests.ini.j2
@@ -40,7 +40,7 @@ subsubtests = good,wrong_tag,wrong_registry_addr
 #: Allow test to pass if actual result matches this PASS/FAIL value
 docker_expected_exit_status = 0
 
-{% if test_image_fqin is defined and ansible_distribution == RedHat %}
+{% if test_image_fqin is defined and ansible_distribution != CentOS %}
 [docker_cli/build/https_file]
 __example__ = dockerfile_dir_path, postproc_cmd_csv
 use_config_repo = no

--- a/roles/autotested/templates/subtests.ini.j2
+++ b/roles/autotested/templates/subtests.ini.j2
@@ -39,3 +39,18 @@ docker_pull_timeout = 120.0
 subsubtests = good,wrong_tag,wrong_registry_addr
 #: Allow test to pass if actual result matches this PASS/FAIL value
 docker_expected_exit_status = 0
+
+{% if test_image_fqin is defined and ansible_distribution == RedHat %}
+[docker_cli/build/https_file]
+__example__ = dockerfile_dir_path, postproc_cmd_csv
+use_config_repo = no
+# This dockerfile pulls the CentOS base image, account for
+# this as img_count('2') below.
+dockerfile_dir_path = https://raw.githubusercontent.com/autotest/autotest-docker/master/subtests/docker_cli/build/full/Dockerfile
+postproc_cmd_csv = positive(),
+                   rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
+                   cnt_count('0'),
+                   img_count('2'),
+                   img_exst(),
+                   intr_exst()
+{% endif %}


### PR DESCRIPTION
This test relies on building from a remote, https based docker file.
The test file uses the CentOS base image, so rather than use a different
url, just patch up the configuration for the extra build pull.

Signed-off-by: Chris Evich <cevich@redhat.com>