### PR TITLE
Pass peon metadata name into results2junit

### DIFF
--- a/roles/autotested/tasks/produce_results.yml
+++ b/roles/autotested/tasks/produce_results.yml
@@ -10,13 +10,22 @@
         autotest_execution is defined and
         autotest_execution|success
 
+- debug:
+    msg: "I am {{ peon_metadata.name }}"
+  when: peon_metadata is defined
+
+# Extract a name unique to this run, but common across runs of same job
 - name: Attempt to run alternate results2junit
-  shell: "{{ autotest_docker_path }}/results2junit --name {{ inventory_hostname }} results/default > {{ autotest_dest_dir }}/client/results/default/results.junit"
+  shell: >
+    {{ autotest_docker_path }}/results2junit
+        --name {{ peon_metadata.name }}
+        results/default
   args:
     chdir: "{{ autotest_dest_dir }}/client"
   register: results2junit
   ignore_errors: true
-  when: docker_autotest.execute and
+  when: peon_metadata is defined and
+        docker_autotest.execute and
         autotest_execution is defined and
         autotest_execution | success
 

--- a/roles/openstack/tasks/setup.yml
+++ b/roles/openstack/tasks/setup.yml
@@ -18,11 +18,10 @@
 
 - block:
 
-    #- debug:
-    #    msg: "Going to create peon {{ peon.uuid }}"
-    #  with_items: "{{ peon_set }}"
-    #  loop_control:
-    #    loop_var: peon
+    - name: host_vars directory exists
+      file:
+        path: '{{ adept_path }}/host_vars'
+        state: directory
 
     # Does not wait for 'ACTIVE' state
     - include: roles/openstack/tasks/create_peons.yml
@@ -30,8 +29,9 @@
       loop_control:
         loop_var: peon
 
-    # Waits for 'ACTIVE' state + defines peon_facts
+    # Waits for 'ACTIVE' state + defines peon_facts (exits block)
     - include: roles/openstack/tasks/facts.yml
+
 
   rescue:
     - include: roles/openstack/tasks/cleanup.yml
@@ -40,3 +40,11 @@
         cleanup_peon_facts: False
         cleanup_clouds_yaml: False
   when: peon_facts is undefined
+
+- name: peon's metadata written into its host_vars
+  copy:
+    dest: '{{ adept_path}}/host_vars/{{ peon.uuid}}.yml'
+    content: "peon_metadata: {{ peon | to_nice_json }}"
+  with_items: "{{ peon_set }}"
+  loop_control:
+    loop_var: peon


### PR DESCRIPTION
Test VMs (peons) are all assigned a globally unique name to prevent
clashes with concurrently running jobs.  This is not a good name to use
for tagging test results because they will never align from run-to-run.

This change makes the peon and cloud metadata available to them via
host_vars.  Later, when the autotest role is applied, it's possible to
extract the peon's uncompounded (basic definition) name.  This is
guaranteed unique within a run, but will be (mostly) shared across
them.

Signed-off-by: Chris Evich <cevich@redhat.com>