### PR TITLE
Support specifying alternate RHSM URLs.

### DIFF
--- a/roles/subscribed/defaults/main.yml
+++ b/roles/subscribed/defaults/main.yml
@@ -4,6 +4,10 @@ rhsm:
     # Empty-list is sentinel (unset) value
     username: []
     password: []
+    # Null value defaults to omitted
+    baseurl:
+    hostname:
+    insecure:
     # Set true to unsubscribe system at end of testing
     unsubscribe: true
 

--- a/roles/subscribed/tasks/main.yml
+++ b/roles/subscribed/tasks/main.yml
@@ -3,9 +3,12 @@
 - name: System is registered and subscribed
   redhat_subscription:
   args:
-    autosubscribe: yes
+    autosubscribe: True
     username: "{{ rhsm.username }}"
     password: "{{ rhsm.password }}"
+    rhsm_baseurl: "{{ rhsm.baseurl | default(omit) }}"
+    server_hostname: "{{ rhsm.hostname | default(omit) }}"
+    insecure: "{{ rhsm.insecure | default(omit) }}"
     state: present
   register: result
   until: result | success


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>