### PR TITLE
Fix ignored-failure on atomic upgrade

### DIFF
--- a/group_vars/centosatomic/storage.yml
+++ b/group_vars/centosatomic/storage.yml
@@ -5,5 +5,11 @@ lvol_ops:
       size: 512
       state: present
       vg: atomicos
+    - lv: root
+      vg: atomicos
+      size: 5g
+
+post_cmnds:
+    - "/usr/sbin/xfs_growfs /"
 
 swap_device: /dev/atomicos/swap

--- a/group_vars/fedoratomic/storage.yml
+++ b/group_vars/fedoratomic/storage.yml
@@ -5,5 +5,11 @@ lvol_ops:
       size: 512
       state: present
       vg: atomicos
+    - lv: root
+      vg: atomicos
+      size: 5g
+
+post_cmnds:
+    - "/usr/sbin/xfs_growfs /"
 
 swap_device: /dev/atomicos/swap

--- a/group_vars/rhelatomic/storage.yml
+++ b/group_vars/rhelatomic/storage.yml
@@ -5,5 +5,11 @@ lvol_ops:
       size: 512
       state: present
       vg: atomicos
+    - lv: root
+      vg: atomicos
+      size: 5g
+
+post_cmnds:
+    - "/usr/sbin/xfs_growfs /"
 
 swap_device: /dev/atomicos/swap

--- a/peons.yml
+++ b/peons.yml
@@ -25,11 +25,10 @@
             parted_cmds is defined and parted_cmds != ''
 
     - role: rebooted
+      # Workaround "feature" of role only being applied once per play
+      run_more_than_once: "foo"
       when: needs_reboot == True
 
-# Allow rebooted role to apply again if needed
-- hosts: peons:&{{ adept_job }}
-  roles:
     - role: yumrepos
       when: disable_all_rh_repos is defined and
             yum_repos is defined and yum_repos != []
@@ -52,11 +51,9 @@
             "atomic_upgrade" in group_names
 
     - role: rebooted
+      run_more_than_once: "bar"
       when: needs_reboot == True
 
-# Allow rebooted role to apply third time if needed
-- hosts: peons:&{{ adept_job }}
-  roles:
     - peon
 
     - role: docker-storage-setup
@@ -67,6 +64,7 @@
     - services
 
     - role: rebooted
+      run_more_than_once: "baz"
       when: needs_reboot == True
 
     # Must be very last role

--- a/peons.yml
+++ b/peons.yml
@@ -69,3 +69,5 @@
     - role: rebooted
       when: needs_reboot == True
 
+    # Must be very last role
+    - touchstone

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -40,6 +40,8 @@
       changed_when: atomic_host_upgrade.rc == 0 or
                     atomic_host_upgrade.rc == 77
       failed_when: atomic_host_upgrade.rc not in [0,77]  # BZ1313540
+      until: atomic_host_upgrade | success
+      retries: 3
 
   always:
 

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -39,18 +39,7 @@
       register: atomic_host_upgrade
       changed_when: atomic_host_upgrade.rc == 0 or
                     atomic_host_upgrade.rc == 77
-      ignore_errors: true
-
-    - name: Workaround BZ1313540
-      fail:
-        msg: "atomic host upgrade failed with unknown error: {{ atomic_host_upgrade }}"
-      when: atomic_host_upgrade.rc != 0 and atomic_host_upgrade.rc != 77
-
-    - name: rpms_updated + needs_reboot are set on update
-      set_fact:
-        rpms_updated: True
-        needs_reboot: True
-      when: atomic_host_upgrade | changed
+      failed_when: atomic_host_upgrade.rc not in [0,77]  # BZ1313540
 
   always:
 
@@ -60,6 +49,16 @@
         state: enforcing
 
   when: _needs_upgrade
+
+- name: Verify upgrade exited 0 or 77 (BZ1313540)
+  assert:
+    that: atomic_host_upgrade.rc == 0 or atomic_host_upgrade.rc == 77
+
+- name: rpms_updated + needs_reboot are set on update
+  set_fact:
+    rpms_updated: True
+    needs_reboot: True
+  when: atomic_host_upgrade | changed
 
 - name: rpms_updated is set false
   set_fact:

--- a/roles/lvm/defaults/main.yml
+++ b/roles/lvm/defaults/main.yml
@@ -3,3 +3,6 @@ installed_enablerepo: []
 installed_disablerepo: []
 lvg_ops: []
 lvol_ops: []
+
+# List of commands (strings) to run if any lvg_ops or lvol_ops change
+post_cmnds: []

--- a/roles/lvm/tasks/main.yml
+++ b/roles/lvm/tasks/main.yml
@@ -16,6 +16,10 @@
 
 - include: roles/lvm/tasks/main_debug.yml
 
+- name: post_cmnd_flag starts out false
+  set_fact:
+    post_cmnd_flag: False
+
 # Condition should apply to task, not each iteration
 - block:
 
@@ -27,7 +31,13 @@
         state: '{{ item.state | default(omit) }}'
         vg: '{{ item.vg | default(omit) }}'
         vg_options: '{{ item.vg_options | default(omit) }}'
+      register: result
       with_items: '{{ lvg_ops }}'
+
+    - name: post_cmnd_flag set True when result changed
+      set_fact:
+        post_cmnd_flag: True
+      when: result | changed
 
   when: lvg_ops != []
 
@@ -43,8 +53,23 @@
         snapshot: '{{ item.snapshot | default(omit) }}'
         state: '{{ item.state | default(omit) }}'
         vg: '{{ item.vg | default(omit) }}'
+      register: result
       with_items: '{{ lvol_ops }}'
+
+    - name: post_cmnd_flag set True when result changed
+      set_fact:
+        post_cmnd_flag: True
+      when: result | changed
 
   when: lvol_ops != []
 
 - include: roles/lvm/tasks/main_debug.yml
+
+
+- block:
+
+    - name: post-lvm operation commands are executed
+      command: '{{ item }}'
+      with_items: '{{ post_cmnds }}'
+
+  when: post_cmnd_flag and post_cmnds != []

--- a/roles/touchstone/tasks/main.yml
+++ b/roles/touchstone/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+
+# Depends:
+#   adept_path
+#   peon_metadata
+# Registers:
+#   touchstone_touched
+
+- name: touchstone_touched flag is set True
+  set_fact:
+    touchstone_touched: True
+
+- name: host_vars directory exists
+  file:
+    path: '{{ adept_path }}/host_vars'
+    state: directory
+  delegate_to: localhost
+
+- name: touchstone_touched persists in host_vars/inventory_hostname
+  lineinfile:
+    create: true
+    dest: '{{ adept_path}}/host_vars/{{ inventory_hostname }}.yml'
+    regexp: 'touchstone_touched.*'
+    line: 'touchstone_touched: True'
+  delegate_to: localhost


### PR DESCRIPTION
Also, give a known fixed size for root storage on atomic hosts and add beginnings of feature to support detection of partially-setup hosts.