### PR TITLE
Sigh. Remove newlines from results2junit call

### DIFF
--- a/roles/autotested/tasks/produce_results.yml
+++ b/roles/autotested/tasks/produce_results.yml
@@ -16,7 +16,7 @@
 
 # Extract a name unique to this run, but common across runs of same job
 - name: Attempt to run alternate results2junit
-  shell: {{ autotest_docker_path }}/results2junit --name {{ peon_metadata.name }} results/default
+  shell: "{{ autotest_docker_path }}/results2junit --name {{ peon_metadata.name }} results/default"
   args:
     chdir: "{{ autotest_dest_dir }}/client"
   register: results2junit

--- a/roles/autotested/tasks/produce_results.yml
+++ b/roles/autotested/tasks/produce_results.yml
@@ -16,10 +16,7 @@
 
 # Extract a name unique to this run, but common across runs of same job
 - name: Attempt to run alternate results2junit
-  shell: >
-    {{ autotest_docker_path }}/results2junit
-        --name {{ peon_metadata.name }}
-        results/default
+  shell: {{ autotest_docker_path }}/results2junit --name {{ peon_metadata.name }} results/default
   args:
     chdir: "{{ autotest_dest_dir }}/client"
   register: results2junit


### PR DESCRIPTION
The new results2junit failed with:

    fatal: [centos-7-2-ADEPT-dockerautotest-...]: FAILED! => {...
       "cmd": "/var/lib/autotest/client/tests/docker/results2junit\n --name centos\n results/default",
       ...,
       "stderr": "usage: results2junit [-h] [-v] [-n] [--name NAME] autotest_results_dir\nresults2junit: error: too few arguments\n/bin/sh: line 1: --name: command not found\n/bin/sh: line 2: results/default: Is a directory",
       ...

Cause: ansible is passing the command with newlines.
Solution: back to just one line

Signed-off-by: Ed Santiago <santiago@redhat.com>