### PR TITLE
Devel

### DIFF
--- a/group_vars/rhel/yumrepos.yml
+++ b/group_vars/rhel/yumrepos.yml
@@ -1,4 +1,13 @@
 ---
 
 disable_all_rh_repos: True
-installed_enablerepo: '{{ enable_rh_repos }}'
+enable_rh_repos:
+    - rhel-7-server-rpms
+    - rhel-7-server-extras-rpms
+    - rhel-7-server-optional-rpms
+    - rhel-7-server-supplementary-rpms
+installed_enablerepo:
+    - rhel-7-server-rpms
+    - rhel-7-server-extras-rpms
+    - rhel-7-server-optional-rpms
+    - rhel-7-server-supplementary-rpms

--- a/group_vars/rhelatomic/autotested.yml
+++ b/group_vars/rhelatomic/autotested.yml
@@ -1,5 +1,7 @@
 ---
 
+_d_a_t_path: "/var/lib/autotest/client/tests/docker"
+
 docker_autotest:
     test_image:
         host: "registry.access.redhat.com"
@@ -9,9 +11,9 @@ docker_autotest:
         build_url:
     templates:
         - src: "{{ custom_subtests_ini_j2 | default('subtests.ini.j2') }}"
-          dest: "{{ autotest_docker_path }}/config_custom/subtests.ini"
+          dest: "{{ _d_a_t_path }}/config_custom/subtests.ini"
         - src: "{{ custom_control_ini_j2 | default('control.ini.j2') }}"
-          dest: "{{ autotest_docker_path }}/config_custom/control.ini"
+          dest: "{{ _d_a_t_path }}/config_custom/control.ini"
     preserve_fqins:
         - "registry.access.redhat.com/rhel7/rhel:latest"
     preserve_cnames: []

--- a/group_vars/rhelatomic/yumrepos.yml
+++ b/group_vars/rhelatomic/yumrepos.yml
@@ -6,3 +6,4 @@ enable_rh_repos:
     - rhel-7-server-extras-rpms
     - rhel-7-server-optional-rpms
     - rhel-7-server-supplementary-rpms
+installed_enablerepo: []

--- a/roles/subscribed/tasks/main.yml
+++ b/roles/subscribed/tasks/main.yml
@@ -1,33 +1,17 @@
 ---
 
-# BUGGED!  rhsm_baseurl/server_hostname documented but unimplemented
-# - name: System is registered and subscribed
-#   redhat_subscription:
-#   args:
-#     autosubscribe: True
-#     username: "{{ rhsm.username }}"
-#     password: "{{ rhsm.password }}"
-#     rhsm_baseurl: "{{ rhsm.baseurl | default(omit) }}"
-#     server_hostname: "{{ rhsm.hostname | default(omit) }}"
-#     server_insecure: "{{ rhsm.insecure | default(omit) }}"
-#     state: present
-#   register: result
-#   when: rhsm.username is defined and
-#         rhsm.username != [] and
-#         rhsm.password is defined and
-#         rhsm.password != []
-#   until: result | success
-#   retries: "{{ rhsm_retries | default(omit) }}"
-#   delay: "{{ rhsm_delay | default(omit) }}"
-
+# rhsm_baseurl/server_hostname only modify configuration in
+# redhat_subscription module.  More reliable to just pass on
+# the command-line directly
 - name: System is registered and subscribed
   shell: >
     subscription-manager register\
                          --username=$RHSM_USERNAME\
                          --password=$RHSM_PASSWORD\
-                         {% if rhsm.insecure %}--insecure{% endif %}\
-                         {% if rhsm.baseurl %}--baseurl={{ rhsm.baseurl }}{% endif %}\
-                         {% if rhsm.hostname %}--serverurl={{ rhsm.hostname }}{% endif %}
+                         --auto-attach\
+                         {% if rhsm.insecure | default(False) %}--insecure {%- endif %}\
+                         {% if rhsm.baseurl | default(False) %}--baseurl={{ rhsm.baseurl }} {%- endif %}\
+                         {% if rhsm.hostname | default(False) %}--serverurl={{ rhsm.hostname }} {%- endif %}
   environment:
     RHSM_USERNAME: "{{ rhsm.username }}"
     RHSM_PASSWORD: "{{ rhsm.password }}"
@@ -39,3 +23,5 @@
   until: result | success
   retries: "{{ rhsm_retries | default(omit) }}"
   delay: "{{ rhsm_delay | default(omit) }}"
+
+- debug: var=result


### PR DESCRIPTION
I accidentally left a dangling reference in ``group_vars/rhel/yumrepos.yml`` to ``enable_rh_repos`` which caused all rpm install/updates to fail.  Also I left out ``--auto-attach`` to the sub-man command, which leads to false-positives on registration/subscription.