### PR TITLE
Slow down rate of kommandir disk filling

### DIFF
--- a/roles/slave/tasks/cleanup.yml
+++ b/roles/slave/tasks/cleanup.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Giblets in kommandir's workspace are removed
+  file:
+    path: "/var/lib/workspace/{ item }"
+    state: absent
+  # No reason to leave these around to soak up diskspace
+  with_items:
+    - adept
+    - cache
+    - dockertest

--- a/roles/slave/tasks/main.yml
+++ b/roles/slave/tasks/main.yml
@@ -24,3 +24,6 @@
 
 - include: roles/slave/tasks/run.yml
   when: adept_context == 'run'
+
+- include: roles/slave/tasks/cleanup.yml
+  when: adept_context == 'cleanup'


### PR DESCRIPTION
"Bad things happen" when there's no more room for workspaces.  The
localhost (slave) role occurs last during cleanup, so all important
details were already synchronized out.  Eventually the disk will still
fill up, but that's a problem for another time.

Signed-off-by: Chris Evich <cevich@redhat.com>