### PR TITLE
Important fixes

### DIFF
--- a/group_vars/docker-latest.yml
+++ b/group_vars/docker-latest.yml
@@ -13,3 +13,5 @@ stopped_services:
     - docker
 
 sysconfig_docker_latest: True
+
+sysconfig_dss_template_dest: "/etc/sysconfig/docker-latest-storage-setup"

--- a/roles/autotested/defaults/main.yml
+++ b/roles/autotested/defaults/main.yml
@@ -6,6 +6,9 @@ docker_autotest_cache_dir: "{{ workspace }}/cache/"
 # Remote directory where Autotest will be installed
 autotest_dest_dir: "/var/lib/autotest"
 
+# Remote directory where autotest-docker will be installed
+autotest_docker_path: "{{ autotest_dest_dir }}/client/tests/docker"
+
 # Timeout in minutes to rewrite into control-file multiplied by 60
 docker_autotest_timeout: 120
 

--- a/roles/autotested/tasks/main.yml
+++ b/roles/autotested/tasks/main.yml
@@ -7,10 +7,6 @@
 - name: Make sure docker client is working
   command: docker version
 
-- name: Base directory of Docker Autotest is defined
-  set_fact:
-    autotest_docker_path: "{{ autotest_dest_dir }}/client/tests/docker"
-
 - name: Autotest directory is removed
   file:
     path: "{{ autotest_dest_dir }}"

--- a/roles/docker-storage-setup/defaults/main.yml
+++ b/roles/docker-storage-setup/defaults/main.yml
@@ -4,10 +4,13 @@
 atomic_storage:
     - reset
 
-# Each item is a line of content for /etc/sysconfig/docker-storage-setup.
+# Destination file for sysconfig_dss_lines or sysconfig_dss_template
+sysconfig_dss_dest: "/etc/sysconfig/docker-storage-setup"
+
+# Each item is a line of content for {{sysconfig_dss_template_dest}}
 # Any existing content will be commented out
 sysconfig_dss_lines: []
 
-# If defined, and above is empty, render this template as
-# /etc/sysconfig/docker-storage-setup
+# Alternative to sysconfig_dss_lines if it is empty,
+# render from this template file instead
 sysconfig_dss_template: ""

--- a/roles/docker-storage-setup/tasks/main.yml
+++ b/roles/docker-storage-setup/tasks/main.yml
@@ -9,26 +9,26 @@
   command: "atomic storage {{ item }}"
   with_items: "{{ atomic_storage }}"
 
-- name: render /etc/sysconfig/docker-storage-setup from template
+- name: render sysconfig_dss_dest from template
   template:
     backup: True
-    dest: /etc/sysconfig/docker-storage-setup
+    dest: "{{ sysconfig_dss_dest }}"
     src: "{{ sysconfig_dss_template }}"
   when: sysconfig_dss_template != ""
 
 - block:
 
-    - name: Comment out all /etc/sysconfig/docker-storage-setup lines
+    - name: Comment out all sysconfig_dss_dest lines
       replace:
         backup: True
-        dest: /etc/sysconfig/docker-storage-setup
+        dest: "{{ sysconfig_dss_dest }}"
         regexp: "^(.*)"
         replace: "# \\1"
 
-    - name: Add lines to /etc/sysconfig/docker-storage-setup
+    - name: Add lines to sysconfig_dss_dest
       lineinfile:
         backup: False
-        dest: /etc/sysconfig/docker-storage-setup
+        dest: "{{ sysconfig_dss_dest }}"
         line: "{{ item }}"
       with_items: '{{ sysconfig_dss_lines }}'
 


### PR DESCRIPTION
Some jobs are failing in the autotested role due to undefined variable.  All docker-latest peons with non-default d-s-s configuration should be using ``/etc/sysconfig/docker-latest-storage-setup`` instead.