### PR TITLE
Workaround RH BZ 1411948

### DIFF
--- a/roles/docker-storage-setup/defaults/main.yml
+++ b/roles/docker-storage-setup/defaults/main.yml
@@ -1,9 +1,5 @@
 ---
 
-# After stopping docker, these parameters will be fed to 'atomic storage'.
-atomic_storage:
-    - reset
-
 # Destination file for sysconfig_dss_lines or sysconfig_dss_template
 sysconfig_dss_dest: "/etc/sysconfig/docker-storage-setup"
 

--- a/roles/docker-storage-setup/tasks/main.yml
+++ b/roles/docker-storage-setup/tasks/main.yml
@@ -1,39 +1,40 @@
 ---
 
-- name: docker service is stopped
-  service:
-    name: docker
-    state: stopped
-
-- name: Atomic storage commands are run
-  command: "atomic storage {{ item }}"
-  with_items: "{{ atomic_storage }}"
-
-- name: render sysconfig_dss_dest from template
-  template:
-    backup: True
-    dest: "{{ sysconfig_dss_dest }}"
-    src: "{{ sysconfig_dss_template }}"
-  when: sysconfig_dss_template != ""
-
 - block:
 
-    - name: Comment out all sysconfig_dss_dest lines
-      replace:
+    - name: docker service is stopped
+      service:
+        name: docker
+        state: stopped
+
+    - name: render sysconfig_dss_dest from template
+      template:
         backup: True
         dest: "{{ sysconfig_dss_dest }}"
-        regexp: "^(.*)"
-        replace: "# \\1"
+        src: "{{ sysconfig_dss_template }}"
+      when: sysconfig_dss_template != ""
 
-    - name: Add lines to sysconfig_dss_dest
-      lineinfile:
-        backup: False
-        dest: "{{ sysconfig_dss_dest }}"
-        line: "{{ item }}"
-      with_items: '{{ sysconfig_dss_lines }}'
+    - block:
 
-  when: sysconfig_dss_lines != []
+        - name: Comment out all sysconfig_dss_dest lines
+          replace:
+            backup: True
+            dest: "{{ sysconfig_dss_dest }}"
+            regexp: "^(.*)"
+            replace: "# \\1"
 
-- name: docker storage is (re)configured
-  command: docker-storage-setup
-  register: result
+        - name: Add lines to sysconfig_dss_dest
+          lineinfile:
+            backup: False
+            dest: "{{ sysconfig_dss_dest }}"
+            line: "{{ item }}"
+          with_items: '{{ sysconfig_dss_lines }}'
+
+      when: sysconfig_dss_lines != []
+
+    - name: docker storage is (re)configured
+      command: docker-storage-setup
+      register: result
+
+  when: sysconfig_dss_template != "" or
+        sysconfig_dss_lines != []


### PR DESCRIPTION
Later versions of the atomic storage reset command misidentify the
empty /var/lib/docker-latest and issue an error message.  Fix this
by removing the tasks which run atomic storage reset.  This works
in all cases because any atomic hosts have already setup by cloud-init
and non-atomic hosts have not started any services yet.

Also, block the d-s-s role with conditionals so that the docker service state
isn't affected if no d-s-s changes are requested.

Signed-off-by: Chris Evich <cevich@redhat.com>