### PR TITLE
Fix registered system re-registration failed.

### DIFF
--- a/roles/subscribed/tasks/main.yml
+++ b/roles/subscribed/tasks/main.yml
@@ -20,6 +20,8 @@
         rhsm.username != [] and
         rhsm.password is defined and
         rhsm.password != []
+  failed_when: result.rc != 0 and
+               not result.stderr | search("system is already registered")
   until: result | success
   retries: "{{ rhsm_retries | default(omit) }}"
   delay: "{{ rhsm_delay | default(omit) }}"


### PR DESCRIPTION
Don't fail the host if it's already registered, this is the desired state.

Signed-off-by: Chris Evich <cevich@redhat.com>