### PR TITLE
Fix docker-latest / d-s-s group var + role order

### DIFF
--- a/group_vars/docker-latest.yml
+++ b/group_vars/docker-latest.yml
@@ -14,4 +14,4 @@ stopped_services:
 
 sysconfig_docker_latest: True
 
-sysconfig_dss_template_dest: "/etc/sysconfig/docker-latest-storage-setup"
+sysconfig_dss_dest: "/etc/sysconfig/docker-latest-storage-setup"

--- a/group_vars/docker-latest.yml
+++ b/group_vars/docker-latest.yml
@@ -13,5 +13,3 @@ stopped_services:
     - docker
 
 sysconfig_docker_latest: True
-
-sysconfig_dss_dest: "/etc/sysconfig/docker-latest-storage-setup"

--- a/peons.yml
+++ b/peons.yml
@@ -60,10 +60,10 @@
 
     - peon
 
+    - sysconfig_docker
+
     - role: docker-storage-setup
       when: sysconfig_dss_lines != [] or sysconfig_dss_template != ""
-
-    - sysconfig_docker
 
     - services
 

--- a/roles/docker-storage-setup/defaults/main.yml
+++ b/roles/docker-storage-setup/defaults/main.yml
@@ -1,8 +1,5 @@
 ---
 
-# Destination file for sysconfig_dss_lines or sysconfig_dss_template
-sysconfig_dss_dest: "/etc/sysconfig/docker-storage-setup"
-
 # Each item is a line of content for {{sysconfig_dss_template_dest}}
 # Any existing content will be commented out
 sysconfig_dss_lines: []

--- a/roles/docker-storage-setup/tasks/main.yml
+++ b/roles/docker-storage-setup/tasks/main.yml
@@ -7,6 +7,9 @@
         name: docker
         state: stopped
 
+    - debug:
+        var: "sysconfig_dss_dest"
+
     - name: render sysconfig_dss_dest from template
       template:
         backup: True

--- a/roles/docker-storage-setup/tasks/main.yml
+++ b/roles/docker-storage-setup/tasks/main.yml
@@ -7,29 +7,39 @@
         name: docker
         state: stopped
 
-    - debug:
-        var: "sysconfig_dss_dest"
-
-    - name: render sysconfig_dss_dest from template
+    - name: render sysconfig/d-s-s & latest, from template
       template:
         backup: True
-        dest: "{{ sysconfig_dss_dest }}"
+        dest: "{{ item }}"
         src: "{{ sysconfig_dss_template }}"
       when: sysconfig_dss_template != ""
+      with_items:
+        - "/etc/sysconfig/docker-storage-setup"
+        - "/etc/sysconfig/docker-latest-storage-setup"
 
     - block:
 
-        - name: Comment out all sysconfig_dss_dest lines
+        - name: Comment out all sysconfig/d-s-s & latest, lines
           replace:
             backup: True
-            dest: "{{ sysconfig_dss_dest }}"
+            dest: "{{ item }}"
             regexp: "^(.*)"
             replace: "# \\1"
+          with_items:
+            - "/etc/sysconfig/docker-storage-setup"
+            - "/etc/sysconfig/docker-latest-storage-setup"
 
-        - name: Add lines to sysconfig_dss_dest
+        - name: Add lines to sysconfig/d-s-s
           lineinfile:
             backup: False
-            dest: "{{ sysconfig_dss_dest }}"
+            dest: "/etc/sysconfig/docker-storage-setup"
+            line: "{{ item }}"
+          with_items: '{{ sysconfig_dss_lines }}'
+
+        - name: Add lines to sysconfig/d-s-s latest
+          lineinfile:
+            backup: False
+            dest: "/etc/sysconfig/docker-latest-storage-setup"
             line: "{{ item }}"
           with_items: '{{ sysconfig_dss_lines }}'
 


### PR DESCRIPTION
The docker-latest group variables file had a misspelling of
a variable name that was causing the incorrect file to be updated:

/etc/sysconfig/docker-storage-setup

instead of

/etc/sysconfig/docker-latest-storage-setup

Also, the d-s-s role was being applied before /etc/sysconfig/docker had
it's DOCKERBINARY updated to docker-latest.  Fixed by re-ordering the
roles in peons.yml

Signed-off-by: Chris Evich <cevich@redhat.com>