### PR TITLE
Fix d-s-s not running if dir exists

### DIFF
--- a/roles/docker-storage-setup/tasks/main.yml
+++ b/roles/docker-storage-setup/tasks/main.yml
@@ -45,9 +45,14 @@
 
       when: sysconfig_dss_lines != []
 
-    - name: docker storage is (re)configured
-      command: docker-storage-setup
-      register: result
+    # Necessary so docker / docker-latest service properly runs d-s-s
+    - name: The /var/lib/docker and docker-latest directories are empty
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - "/var/lib/docker"
+        - "/var/lib/docker-latest"
 
   when: sysconfig_dss_template != "" or
         sysconfig_dss_lines != []


### PR DESCRIPTION
Even if /etc/sysconfig/d-s-s or docker-latest-s-s is re-configured, if
either /var/lib/docker* directory exists, then d-s-s will not run.
Also, on newer docker-latest packages, d-s-s needs to be called as:
docker-latest-storage-setup.  Rather than try and guess which to use,
when, just remove both directories and allow the docker/docker-latest
systemd services to "do the right thing".

Signed-off-by: Chris Evich <cevich@redhat.com>