### PR TITLE
Rename/Change yumrepos gpgcheck input arg. name.

### DIFF
--- a/roles/yumrepos/defaults/main.yml
+++ b/roles/yumrepos/defaults/main.yml
@@ -1,6 +1,25 @@
 ---
 
+# There are situations where default repositories are broken.
+# Setting this true causes ALL subscription-manager supplied repos
+# to be disabled.
 disable_all_rh_repos: False
+
+# This is the opposite of ``disable_all_rh_repos`` (above).  It's
+# a list of subscription-manager supplied repos to explicitly enable.
 enable_rh_repos: []
-# empty-list is (unset) sentinel value
+
+# When neither of the above meet testing requirements, or additional
+# local repositories should be added, this specifies them.  Each item
+# in the list is a dictionary of arguments to the standard 
+# ``yum_repository`` Ansible module.  e.g.
+#
+# yum_repos:
+#     - name: "My special Repo"
+#       baseurl: "https://my.special.repo.example.com/"
+#       gpgcheck: False
+#       includepkgs: rocket2moon
+#     - name: "Other special repo"
+#       baseurl: "https://you.get.the.idea"
+#
 yum_repos: []

--- a/roles/yumrepos/tasks/main.yml
+++ b/roles/yumrepos/tasks/main.yml
@@ -15,7 +15,7 @@
     name: "{{ item.name | mandatory }}"
     baseurl: "{{ item.baseurl }}"
     description: "Ansible added {{ item.name | mandatory }} repo"
-    gpgcheck: "{{ item.exclude | default(False) }}"
+    gpgcheck: "{{ item.gpgcheck | default(True) }}"
     exclude: "{{ item.excludepkgs | default(omit) }}"
     includepkgs: "{{ item.includepkgs | default(omit) }}"
     metadata_expire: 900  # quarter-hour


### PR DESCRIPTION
No idea why 'exclude' was used, probably a copy-paste typo on my part.
Also defaulting to 'False' (i.e. --nogpgcheck) isn't the correct
behavior.  It's important to spot instances where packages are unsigned,
and they should be.  This change will cause those cases to (correctly)
fail.

For cases where development/test repos. are being used, their
list item args will need to be updated with 'gpgcheck: False'
to get the correct (previous) behavior.  Assuming that devel/test
repos don't generally sign packages.

Signed-off-by: Chris Evich <cevich@redhat.com>