### PR TITLE
Atomic requires use of a rsyslog system container

### DIFF
--- a/roles/autotested/templates/control.ini.j2
+++ b/roles/autotested/templates/control.ini.j2
@@ -18,8 +18,10 @@ exclude = example,subexample,pretest_example,intratest_example,
           posttest_example,
           docker_cli/run_volumes,
 {# Atomic host does not have git #}
+{# Atomic host has trimmed down logging #}
           {% if is_atomic %}
           docker_cli/build/git_path,
+          docker_cli/syslog
 {% endif %}
 {% if not is_enterprise %}
           {# We never test the RHEL base-image on CentOS #}


### PR DESCRIPTION
Long ago, bits were stripped from Atomic to make it smaller.  That
included removing rsyslog (needed to flush from journal to messages).
Though I have no idea why the syslog subtest has been passing on CentOS
Atomic, it's not a setup that we need to test.  Exclude the syslog
subtest from testing on Atomic hosts, only run it on full-OS systems.

Signed-off-by: Chris Evich <cevich@redhat.com>