### PR TITLE
Fix: timeouts during install/upgrade

### DIFF
--- a/roles/atomic_upgrade/defaults/main.yml
+++ b/roles/atomic_upgrade/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 
 rpms_updated: False
+
+# Max time to poll for update/install results on remote host.
+async_poll_timeout: 300

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -50,6 +50,9 @@
       async: '{{ async_poll_timeout }}'
       poll: 10
 
+    - debug:
+        var: 'atomic_host_upgrade'
+
     - assert:
         that:
             - 'atomic_host_upgrade.rc is defined'

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -42,11 +42,18 @@
     - name: Atomic host is updated to latest tree
       command: atomic host upgrade
       register: atomic_host_upgrade
-      changed_when: atomic_host_upgrade.rc in [0,77]
-      failed_when: atomic_host_upgrade.rc not in [0,77]  # BZ1313540
+      # Check in assert, changed_when/failed_when based on
+      # atomic_host_upgrade's rc key is not reliable.
+      # Sometimes the key doesn't exist at time of check.
+      ignore_errors: True
       # Depending on networking, this could take a while.
       async: '{{ async_poll_timeout }}'
       poll: 10
+
+    - assert:
+        that:
+            - 'atomic_host_upgrade.rc is defined'
+            - 'atomic_host_upgrade.rc in [0,77]'
 
   always:
 

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -45,6 +45,9 @@
       changed_when: atomic_host_upgrade.rc in [0,77]
       failed_when: atomic_host_upgrade.rc not in [0,77]  # BZ1313540
       until: atomic_host_upgrade | success
+      # Depending on networking, this could take a while.
+      async: '{{ async_poll_timeout }}'
+      poll: 10
       retries: 3
 
   always:

--- a/roles/atomic_upgrade/tasks/main.yml
+++ b/roles/atomic_upgrade/tasks/main.yml
@@ -44,11 +44,9 @@
       register: atomic_host_upgrade
       changed_when: atomic_host_upgrade.rc in [0,77]
       failed_when: atomic_host_upgrade.rc not in [0,77]  # BZ1313540
-      until: atomic_host_upgrade | success
       # Depending on networking, this could take a while.
       async: '{{ async_poll_timeout }}'
       poll: 10
-      retries: 3
 
   always:
 

--- a/roles/installed/defaults/main.yml
+++ b/roles/installed/defaults/main.yml
@@ -10,3 +10,6 @@ rpms_installed: False
 # For use by other roles, bypasses reference to possibly overriden
 # installed_rpms
 _installed_rpms: []
+
+# Max time to poll for update/install results on remote host.
+async_poll_timeout: 300

--- a/roles/installed/tasks/main.yml
+++ b/roles/installed/tasks/main.yml
@@ -73,6 +73,9 @@
         update_cache: true
       with_items: '{{ _installed_rpms }}'
       register: rpms_installed
+      # Depending on networking, this could take a while.
+      async: '{{ async_poll_timeout }}'
+      poll: 10
 
     - name: rpms_installed reflects changed status
       set_fact:
@@ -90,6 +93,8 @@
         disablerepo: '{{ _disablerepo }}'
       with_items: '{{ _installed_rpms }}'
       register: rpms_installed
+      async: '{{ async_poll_timeout }}'
+      poll: 10
 
     - name: rpms_installed reflects changed status
       set_fact:

--- a/roles/updated/defaults/main.yml
+++ b/roles/updated/defaults/main.yml
@@ -5,3 +5,6 @@ updated_enablerepo: []
 updated_disablerepo: []
 use_dnf: False
 rpms_updated: False
+
+# Max time to poll for update/install results on remote host.
+async_poll_timeout: 300


### PR DESCRIPTION
Ansible docs state "operations that take longer than the ssh
timeout will fail".  This is certainly more likely to happen with large
package installs/atomic updates depending on networking conditions.
Reduce dependency on low-latency networking by monitoring the
install/update via polling.

Signed-off-by: Chris Evich <cevich@redhat.com>