### PR TITLE
fixup! Simplify fix fatal exit

### DIFF
--- a/__exekutir__/cleanup_before_job.yml
+++ b/__exekutir__/cleanup_before_job.yml
@@ -1,3 +1,41 @@
 ---
 
-- include: setup_before_job.yml
+- hosts: exekutir
+  gather_facts: False
+  pre_tasks:
+    - name: Gather exekutir facts exclusive of other inventory hosts
+      setup:
+  roles:
+    - common
+    - ansible_versioned
+    - compatible_ansible
+    - exekutir_workspace_setup
+    - role: inventory_updated
+      inventory_hostnames:
+        - exekutir
+
+- hosts: kommandir
+  gather_facts: False
+  force_handlers: True
+  roles:
+    - common
+    - role: exekutir_lock
+      lock_type: "exclusive"
+    - kommandir_discovered
+    - role: inventory_updated
+      inventory_hostnames:
+        - kommandir
+        - exekutir
+    - kommandir_up
+    - kommandir_installed
+    - role: exekutir_lock
+      lock_type: "shared"
+      lock_release: False
+  # Exclusive lock is released by handler, shared lock maintained
+
+- hosts: kommandir
+  roles:
+    - common
+    - kommandir_workspace_setup
+    - kommandir_to_exekutir_sync
+  # Shared lock is maintained

--- a/__exekutir__/setup_before_job.yml
+++ b/__exekutir__/setup_before_job.yml
@@ -3,6 +3,8 @@
 - hosts: exekutir
   # Assume inventory is incomplete (kommandir is unreachable)
   gather_facts: False
+  # Guarantee immediate non-zero exit, do not continue w/ other hosts
+  any_errors_fatal: true
   pre_tasks:
     - name: Gather exekutir facts exclusive of other inventory hosts
       setup:
@@ -20,6 +22,8 @@
   gather_facts: False
   # Ensure exclusive lock is released, even on role failure
   force_handlers: True
+  # Guarantee immediate non-zero exit, do not continue w/ other hosts
+  any_errors_fatal: true
   roles:
     - common
     - role: exekutir_lock
@@ -37,6 +41,8 @@
   # Exclusive lock is released by handler, shared lock maintained
 
 - hosts: kommandir
+  # Guarantee immediate non-zero exit, do not continue w/ other hosts
+  any_errors_fatal: true
   roles:
     - common
     # One-time setup, then synchronizes from exekutir -> kommandir

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -3,18 +3,18 @@ Operational Overview
 
 FIXME: rough-draft
 
-* Fundimental setup of exekutir's ssh keys, and copying __exekutir__ dir.
-  into $WORKSPACE.
-
 * The 'setup' context transition
 
-    * Intermediate exekutir setup, check ansible version, setup
-      separate kommandir workspace source directory.
+    * Fundimental setup of exekutir's ssh keys, and copying __exekutir__ dir.
+      into $WORKSPACE.  (exekutir.xn)
 
-    * Exekutir acquires exclusive lock
+    * Intermediate exekutir setup, check ansible version, setup
+      separate kommandir workspace source directory. (setup_before_job.yml)
+
+    * Exekutir acquires exclusive lock 
 
         * Create or discover the kommandir VM by running a script.  YAML
-          output from script updates kommandir's variables.
+          output from script updates kommandir's host_vars in inventory.
 
         * Wait for Kommandir to ping, and test ability to run "sleep 0.1".
 
@@ -39,20 +39,20 @@ FIXME: rough-draft
 
         * Remotely run job.xn on kommandir.  Presumed this will
           provision and install all peon VMs (in parallel), deploying
-          cache contents to them, and prepare them for testing.
+          cache contents to them, and prepare them for testing. (exekutir.xn)
 
         * For remote kommandir's, rsync workspace back to exekutir's
-          copy.
+          copy. (setup_after_job.yml)
 
-    * Exekutir releases shared lock
+    * Exekutir releases shared lock (setup_after_job.yml)
 
 
 * The 'run' context transition
 
-    * Exekutir acquires exclusive lock
+    * Exekutir acquires exclusive lock (run_before_job.yml)
 
         * Create or discover the kommandir VM by running a script.  YAML
-          output from script updates kommandir's variables.
+          output from script updates kommandir's variables. 
 
         * Wait for Kommandir to ping, and test ability to run "sleep 0.1".
 
@@ -63,15 +63,16 @@ FIXME: rough-draft
 
     * Exekutir releases exclusive lock (maintaining shared lock)
 
-        * For remote kommandir's, destructive rsync exekutir's
+        * For remote kommandir's, rsync exekutir's
           copy of kommandir's workspace to kommandir.
 
         * Remotely run job.xn on kommandir.  Presumed this will
           execute testing on all peons in parallel, then package
           up all result files in kommandir's workspace.
+          (exekutir.xn -> job.xn)
 
         * For remote kommandir's, rsync workspace back to exekutir's
-          copy.
+          copy. (run_after_job.yml)
 
     * Exekutir releases shared lock
 
@@ -79,7 +80,7 @@ FIXME: rough-draft
    not setup or run happened or completed successfully.  Must be
    very tolerant of missing files and unexpected state.
 
-    * Exekutir acquires exclusive lock
+    * Exekutir acquires exclusive lock (cleanup_before_job.yml)
 
         * Create or discover the kommandir VM by running a script.  YAML
           output from script updates kommandir's variables.
@@ -93,17 +94,17 @@ FIXME: rough-draft
 
     * Exekutir releases exclusive lock (maintaining shared lock)
 
-        * For remote kommandir's, destructive rsync exekutir's
+        * For remote kommandir's, rsync exekutir's
           copy of kommandir's workspace to kommandir.  Failure
-          blocks next step.
+          blocks next step. 
 
         * Remotely run job.xn on kommandir.  Presumed this will
           destroy all peons and release any other resources
           (extra storage volumes, networking, etc.).  Failure
-          does NOT block next step.
+          does NOT block next step. (exekutir.xn -> job.xn)
 
         * For remote kommandir's, rsync workspace back to exekutir's
-          copy.  Failure possible, but unlikely
+          copy.  (cleanup_after_job.yml)
 
     * Exekutir releases shared lock
 
@@ -119,3 +120,7 @@ FIXME: rough-draft
           disk filling.
 
     * Exekutir releases exclusive lock
+
+    * Exekutir prunes it's copy of Kommandir's workspace, then it's own.
+      Removes cache, symlinks, copy of exekutir roles, exekutir playbooks,
+      and exekutir variables.yml (preserving kommandir's copy).

--- a/exekutir.xn
+++ b/exekutir.xn
@@ -85,6 +85,20 @@
     inventory: "${WORKSPACE}/inventory"
     varsfile: "${WORKSPACE}/variables.yml"
 
+# Pre-job.xn cleanup must be allowed to fail so post-job.xn cleanup may run
+# Transition summary:
+#   cleanup:
+#      - Setup exekutirs workspace, find or create kommandir.
+#      - Setup & sync. exekutir workspace to kommandir workspace.
+- playbook:
+    contexts:
+        - cleanup
+    filepath: "${WORKSPACE}/cleanup_before_job.yml"
+    inventory: "${WORKSPACE}/inventory"
+    varsfile: "${WORKSPACE}/variables.yml"
+    # Special case, do not exit on non-zero, dump to a file for inspection
+    exitfile: "${WORKSPACE}/exekutir_cleanup_before_job.exit"
+
 # Nested call to adept.py on kommandir, exit code is ignored
 # but it is written to a file.
 # Transition summary:
@@ -100,7 +114,19 @@
     # __exekutir__/roles/common/tasks/main.yml depends on this filename
     exitfile: "$WORKSPACE/kommandir_${ADEPT_CONTEXT}.exit"
     arguments: >
-        -c 'cd "${WORKSPACE}/kommandir_workspace";
+        -c 'cd "$WORKSPACE";
+            CLEANUP_BEFORE_FILE="exekutir_cleanup_before_job.exit";
+            # Do not run job.xn cleanup if kommandir discover/create failed
+            if [ -r "$CLEANUP_BEFORE_FILE" ] && \
+               [ "$(cat $CLEANUP_BEFORE_FILE)" != "0" ];
+            then
+                echo "WARNING: Discover/create kommandir for cleanup failed.";
+                echo "Non-zero exit code in $CLEANUP_BEFORE_FILE";
+                echo "NOT running kommandir job.xn";
+                exit 0;
+            fi;
+
+            cd "${WORKSPACE}/kommandir_workspace";
             # variables.yml produced by kommandir_workspace_setup role
             export UUID=$(grep -s -x -m 1 -e "^uuid: .*$" variables.yml | cut -d: -f2 | tr -d [:blank:]);
             echo "Job UUID=$UUID";
@@ -135,7 +161,7 @@
             echo "Returning from nested adept.py job.xn, exit code: $RET";
             exit $RET;'
 
-# For all contexts, ignore exit code, but write it to a file.
+# For all contexts, ignore exit code, always attempt to sync. to exekutir
 # Context Transition summary:
 #   setup:
 #       - sync. kommandir workspace to exekutir
@@ -150,6 +176,5 @@
 - playbook:
     filepath: "${WORKSPACE}/${ADEPT_CONTEXT}_after_job.yml"
     inventory: "${WORKSPACE}/inventory"
-    # Do not fail this adept.py execution with an exit code
     exitfile: "${WORKSPACE}/exekutir_${ADEPT_CONTEXT}.exit"
     varsfile: "${WORKSPACE}/variables.yml"

--- a/test_exekutir_xn.sh
+++ b/test_exekutir_xn.sh
@@ -6,7 +6,8 @@ set -e
 [ -z "$@" ] || ADEPT_OPTIONAL="$@"
 
 export WORKSPACE=$(mktemp -d --suffix=.adept.workspace)
-trap 'rm -rf $WORKSPACE' EXIT
+# Allow workspace inspection in debug mode
+echo "$@" | grep -q -v 'adept_debug' || trap 'rm -rf $WORKSPACE' EXIT
 
 cat << EOF > $WORKSPACE/variables.yml
 ---

--- a/test_exekutir_xn.sh
+++ b/test_exekutir_xn.sh
@@ -28,13 +28,22 @@ mkdir -p $WORKSPACE/cache && date > $WORKSPACE/cache/junk.txt
     ./adept.py run $WORKSPACE exekutir.xn $ADEPT_OPTIONAL && \
     ./adept.py cleanup $WORKSPACE exekutir.xn $ADEPT_OPTIONAL
 
-echo "$(basename $0) Exit: $?"
+echo "adept.py exit: $?"
+echo
 echo "Workspace contents:"
 ls -la $WORKSPACE
+echo
 echo "Kommandir's workspace contents:"
 ls -la $WORKSPACE/kommandir_workspace
+echo
 echo "Variables.yml contents:"
 cat $WORKSPACE/kommandir_workspace/variables.yml
+
+echo
+echo "Examining exit files"
+
+echo "Checking kommandir discovery (before job.xn) cleanup exit file contains 0"
+[ "$(cat ${WORKSPACE}/exekutir_cleanup_before_job.exit)" == "0" ] || exit 1
 
 for context in setup run cleanup
 do


### PR DESCRIPTION
The first commit tries to explain what's fixed here (it's an ansible-ism).  The two other commits are just supporting changes and related uninttest updates.

When any task fails, ansible skips all other tasks for that host, but
continues with tasks for other hosts.  Because pre-job.xn setup tasks
are mandatory, change the default behavior of ansible to exit
immediatly when any task fails.  The play argument
``any_errors_fatal: true`` accomplishes this.

The exception to the above is during the cleanup transition.  That
context must always complete (successful or not).  In other words,
whether or not kommandir re/discovery is successful, there are still
additional tasks to perform on the exekutir.  Allow those cases
by NOT setting ``any_errors_fatal`` in cleanup_before_job.yml