### PR TITLE
fixup! Can't check out tag w/o enough depth

### DIFF
--- a/__exekutir__/inventory/host_vars/kommandir.yml
+++ b/__exekutir__/inventory/host_vars/kommandir.yml
@@ -87,4 +87,6 @@ git_cache_args:
     - repo: "https://github.com/python-bugzilla/python-bugzilla.git"
       recursive: False
       cachepath: "python-bugzilla"
+      # Need to fetch everything to find specific tagged version
+      depth:
       version: "v1.2.2"


### PR DESCRIPTION
By default the fetch depth is set at 2.  This is not deep enough to
locate the tag in the case of python-bugzilla.  Add an argument to the
configured list so the depth is left "None" - meaning fetch
everything.