### PR TITLE
Modifying git depth

### DIFF
--- a/__exekutir__/inventory/host_vars/kommandir.yml
+++ b/__exekutir__/inventory/host_vars/kommandir.yml
@@ -87,4 +87,6 @@ git_cache_args:
     - repo: "https://github.com/python-bugzilla/python-bugzilla.git"
       recursive: False
       cachepath: "python-bugzilla"
+      # Need to fetch everything to find specific tagged version
+      depth:
       version: "v1.2.2"

--- a/__exekutir__/inventory/host_vars/kommandir.yml
+++ b/__exekutir__/inventory/host_vars/kommandir.yml
@@ -87,6 +87,6 @@ git_cache_args:
     - repo: "https://github.com/python-bugzilla/python-bugzilla.git"
       recursive: False
       cachepath: "python-bugzilla"
-      # Need to fetch everything to find specific tagged version
-      depth:
+      # Do not include a 'depth' argument, git needs the full history to be 
+      # able to locate specific commits/branches/tags referenced by 'version'
       version: "v1.2.2"

--- a/__exekutir__/roles/kommandir_workspace_setup/tasks/main.yml
+++ b/__exekutir__/roles/kommandir_workspace_setup/tasks/main.yml
@@ -123,8 +123,9 @@
   git:
     repo: "{{ item.repo }}"
     dest: "{{ kommandir_workspace }}/cache/{{ item.cachepath }}"
-    # Shallow clone is much faster, two commits will cover a merge-commit
-    depth: "{{ item.depth | default(2) }}"
+    # Shallow clone is much faster when specific branch/tag/version is _not_ used.
+    # Otherwise, if a version is specified, then the full history-depth is likely required to find it
+    depth: "{{ omit if item.version is defined else item.depth | default(2) }}"
     # HEAD is the default if not specified
     version: "{{ item.version | default(omit) }}"
     recursive: "{{ item.recursive | default(False) }}"


### PR DESCRIPTION
Since git module_arg depth:2 fails for python-bugzilla repo, omitting it for this repo and setting it individually for the other repos. Please review.