### PR TITLE
Add openstack kommandir provisioning script

### DIFF
--- a/.test_openstack_TestDestroy.test_found.json
+++ b/.test_openstack_TestDestroy.test_found.json
@@ -1,0 +1,380 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-06T19:18:32.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network-name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "9.8.7.6",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-06T19:18:20Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "4c32f2ada1600c5c39c7f948fcbd569b09481d19de3e76b8d8e5e508",
+        "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "rhel",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "b07a393723e745258368caa188a4fc7b",
+        "updated": "2017-03-06T19:18:32Z",
+        "user_id": "a067e689c65744fb972fde2d7a8e0a70"
+      }
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+  {
+    "DELETE": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+    "sequence_number": 30,
+    "status_code": 204,
+    "response": null
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 40,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 50,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 80,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/295eb339-d94a-4a12-8c80-7a2b81d473d6",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 90,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    },
+    "sequence_number": 120,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestDestroy.test_missing.json
+++ b/.test_openstack_TestDestroy.test_missing.json
@@ -1,0 +1,116 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "status_code": 200,
+    "response": {
+      "servers": [
+        {
+          "id": "0e94ba35-7f76-461f-b67a-c6f54802b17b",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "b757e40c-6bbe-4740-b100-50e3aba58936",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/b757e40c-6bbe-4740-b100-50e3aba58936",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/b757e40c-6bbe-4740-b100-50e3aba58936",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "fccbb584-c232-478d-a190-94394a991174",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        },
+        {
+          "id": "994140a2-aab1-4623-9259-da0bf4cdf9b7",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "test"
+        }
+      ]
+    }
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "status_code": 200,
+    "response": {
+      "servers": [
+        {
+          "id": "0e94ba35-7f76-461f-b67a-c6f54802b17b",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "b757e40c-6bbe-4740-b100-50e3aba58936",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/b757e40c-6bbe-4740-b100-50e3aba58936",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/b757e40c-6bbe-4740-b100-50e3aba58936",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        },
+        {
+          "id": "fccbb584-c232-478d-a190-94394a991174",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    }
+  }
+]

--- a/.test_openstack_TestDestroy.test_other.json
+++ b/.test_openstack_TestDestroy.test_other.json
@@ -1,0 +1,74 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "status_code": 200,
+    "response": {
+      "servers": [
+        {
+          "id": "0e94ba35-7f76-461f-b67a-c6f54802b17b",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/0e94ba35-7f76-461f-b67a-c6f54802b17b",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "rhel"
+        },
+        {
+          "id": "fccbb584-c232-478d-a190-94394a991174",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        }
+      ]
+    }
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "status_code": 200,
+    "response": {
+      "servers": [
+        {
+          "id": "fccbb584-c232-478d-a190-94394a991174",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/fccbb584-c232-478d-a190-94394a991174",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        },
+        {
+          "id": "994140a2-aab1-4623-9259-da0bf4cdf9b7",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "test"
+        }
+      ]
+    }
+  }
+]

--- a/.test_openstack_TestDiscoverCreate.test_floating.json
+++ b/.test_openstack_TestDiscoverCreate.test_floating.json
@@ -1,0 +1,384 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+      ]
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/flavors",
+    "response": {
+      "flavors": [
+        {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/something/flavors/3",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "m1.medium"
+        }
+      ]
+    },
+    "sequence_number": 30,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2/images?name=CentOS-Cloud-7&status=active",
+    "response": {
+      "first": "/v2/images?status=active&name=CentOS-Cloud-7",
+      "images": [
+        {
+          "architecture": "x86_64",
+          "checksum": "c2ebde45f03aa35c6d996c3de984a9d6",
+          "container_format": "bare",
+          "created_at": "2017-01-04T17:13:31Z",
+          "description": "https://wiki.centos.org/Download",
+          "disk_format": "qcow2",
+          "file": "/v2/images/the_image_id/file",
+          "id": "the_image_id",
+          "min_disk": 0,
+          "min_ram": 0,
+          "name": "CentOS-Cloud-7",
+          "owner": "something",
+          "protected": true,
+          "schema": "/v2/schemas/image",
+          "self": "/v2/images/the_image_id",
+          "size": 898236416,
+          "status": "active",
+          "tags": [],
+          "updated_at": "2017-01-04T17:14:55Z",
+          "virtual_size": null,
+          "visibility": "private"
+        }
+      ],
+      "schema": "/v2/schemas/images"
+    },
+    "sequence_number": 40,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "adminPass": "supersecret",
+        "id": "foobars_id",
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/foobars_id",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/something/servers/foobars_id",
+            "rel": "bookmark"
+          }
+        ],
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ]
+      }
+    },
+    "sequence_number": 50,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/servers/foobars_id",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "building",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {},
+        "config_drive": "",
+        "created": "2017-03-07T18:27:07Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "big_number",
+        "id": "foobars_id",
+        "image": {
+          "id": "the_image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/images/the_image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/foobars_id",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/something/servers/foobars_id",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "status": "BUILD",
+        "tenant_id": "something",
+        "updated": "2017-03-07T18:27:08Z",
+        "user_id": "the_user_id"
+      }
+    },
+    "sequence_number": 70,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/foobars_id",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T18:27:18.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:51:4e:98",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T18:27:07Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "big_number",
+        "id": "foobars_id",
+        "image": {
+          "id": "the_image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/images/the_image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/foobars_id",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/something/servers/foobars_id",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "something",
+        "updated": "2017-03-07T18:27:18Z",
+        "user_id": "the_user_id"
+      }
+    },
+    "sequence_number": 130,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/routers",
+    "response": {
+      "routers": [
+        {
+          "admin_state_up": true,
+          "external_gateway_info": {
+            "enable_snat": true,
+            "external_fixed_ips": [
+              {
+                "ip_address": "6.5.4.3",
+                "subnet_id": "the_subnet_id"
+              }
+            ],
+            "network_id": "the_network_id"
+          },
+          "id": "some_number",
+          "name": "network_name",
+          "routes": [],
+          "status": "ACTIVE",
+          "tenant_id": "something"
+        }
+      ]
+    },
+    "sequence_number": 140,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/floatingips",
+    "response": {
+      "floatingips": [
+        {
+          "fixed_ip_address": "3.4.5.6",
+          "floating_ip_address": "192.168.1.1",
+          "floating_network_id": "the_network_id",
+          "id": "floating_id",
+          "port_id": "the_port_id",
+          "router_id": "some_number",
+          "status": "ACTIVE",
+          "tenant_id": "something"
+        }
+      ]
+    },
+    "sequence_number": 150,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/v2.0/floatingips",
+    "response": {
+      "floatingip": {
+        "fixed_ip_address": null,
+        "floating_ip_address": "192.168.1.2",
+        "floating_network_id": "the_network_id",
+        "id": "44608161-678a-49cf-b1d5-fc4535910fbf",
+        "port_id": null,
+        "router_id": null,
+        "status": "DOWN",
+        "tenant_id": "something"
+      }
+    },
+    "sequence_number": 160,
+    "status_code": 201
+  },
+  {
+    "POST": "http://1.2.3.4/servers/foobars_id/action"
+  },
+  {
+    "GET": "http://1.2.3.4/servers/foobars_id",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T18:27:18.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:51:4e:98",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:51:4e:98",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "192.168.1.2",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T18:27:07Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "big_number",
+        "id": "foobars_id",
+        "image": {
+          "id": "the_image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/something/images/the_image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/foobars_id",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/something/servers/foobars_id",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "something",
+        "updated": "2017-03-07T18:27:18Z",
+        "user_id": "the_user_id"
+      }
+    },
+    "sequence_number": 170,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestDiscoverCreate.test_found.json
+++ b/.test_openstack_TestDiscoverCreate.test_found.json
@@ -1,0 +1,43 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestDiscoverCreate.test_missing.json
+++ b/.test_openstack_TestDiscoverCreate.test_missing.json
@@ -1,0 +1,563 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        },
+        {
+          "id": "994140a2-aab1-4623-9259-da0bf4cdf9b7",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "fedora"
+        },
+        {
+          "id": "994140a2-aab1-4623-9259-da0bf4cdf9b7",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/994140a2-aab1-4623-9259-da0bf4cdf9b7",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "centos"
+        }
+      ]
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/flavors",
+    "response": {
+      "flavors": [
+        {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "m1.medium"
+        }
+      ]
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2/images?name=CentOS-Cloud-7&status=active",
+    "response": {
+      "first": "/v2/images?status=active&name=CentOS-Cloud-7",
+      "images": [
+        {
+          "architecture": "x86_64",
+          "checksum": "c2ebde45f03aa35c6d996c3de984a9d6",
+          "container_format": "bare",
+          "created_at": "2017-01-04T17:13:31Z",
+          "description": "https://wiki.centos.org/Download",
+          "disk_format": "qcow2",
+          "file": "/v2/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e/file",
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "min_disk": 0,
+          "min_ram": 0,
+          "name": "CentOS-Cloud-7",
+          "owner": "abcd1234",
+          "protected": true,
+          "schema": "/v2/schemas/image",
+          "self": "/v2/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "size": 898236416,
+          "status": "active",
+          "tags": [],
+          "updated_at": "2017-01-04T17:14:55Z",
+          "virtual_size": null,
+          "visibility": "private"
+        }
+      ],
+      "schema": "/v2/schemas/images"
+    },
+    "sequence_number": 30,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "adminPass": "foobar",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ]
+      }
+    },
+    "sequence_number": 40,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": "spawning",
+        "OS-EXT-STS:vm_state": "building",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {},
+        "config_drive": "",
+        "created": "2017-03-07T15:27:45Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "ijkl9012",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "BUILD",
+        "tenant_id": "abcd1234",
+        "updated": "2017-03-07T15:27:46Z",
+        "user_id": "efgh5678"
+      }
+    },
+    "sequence_number": 60,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": "spawning",
+        "OS-EXT-STS:vm_state": "building",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {},
+        "config_drive": "",
+        "created": "2017-03-07T15:27:45Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "ijkl9012",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "BUILD",
+        "tenant_id": "abcd1234",
+        "updated": "2017-03-07T15:27:46Z",
+        "user_id": "efgh5678"
+      }
+    },
+    "sequence_number": 80,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": "spawning",
+        "OS-EXT-STS:vm_state": "building",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {},
+        "config_drive": "",
+        "created": "2017-03-07T15:27:45Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "ijkl9012",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "BUILD",
+        "tenant_id": "abcd1234",
+        "updated": "2017-03-07T15:27:46Z",
+        "user_id": "efgh5678"
+      }
+    },
+    "sequence_number": 100,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T15:27:58.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network-name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:72:04:4d",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "9.8.7.6",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T15:27:45Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "ijkl9012",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "abcd1234",
+        "updated": "2017-03-07T15:27:58Z",
+        "user_id": "efgh5678"
+      }
+    },
+    "sequence_number": 120,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/routers",
+    "response": {
+      "routers": [
+        {
+          "admin_state_up": true,
+          "external_gateway_info": {
+            "enable_snat": true,
+            "external_fixed_ips": [
+              {
+                "ip_address": "192.168.255.255",
+                "subnet_id": "the_subnet_id"
+              }
+            ],
+            "network_id": "the_network_id"
+          },
+          "id": "the_router_id",
+          "name": "network-name",
+          "routes": [],
+          "status": "ACTIVE",
+          "tenant_id": "abcd1234"
+        }
+      ]
+    },
+    "sequence_number": 130,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/floatingips",
+    "response": {
+      "floatingips": [
+        {
+          "fixed_ip_address": "192.168.1.1",
+          "floating_ip_address": "192.168.1.2",
+          "floating_network_id": "the_network_id",
+          "id": "the_floatingip_id",
+          "port_id": "some_port_id",
+          "router_id": "the_router_id",
+          "status": "ACTIVE",
+          "tenant_id": "abcd1234"
+        },
+        {
+          "fixed_ip_address": null,
+          "floating_ip_address": "5.4.3.2",
+          "floating_network_id": "the_network_id",
+          "id": "another_port_id",
+          "port_id": null,
+          "router_id": null,
+          "status": "DOWN",
+          "tenant_id": "abcd1234"
+        }
+      ]
+    },
+    "sequence_number": 160,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156/action"
+  },
+  {
+    "GET": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T15:27:58.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network-name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:72:04:4d",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "9.8.7.6",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:72:04:4d",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T15:27:45Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "ijkl9012",
+        "id": "e1615934-d188-4994-981a-036e5216b156",
+        "image": {
+          "id": "b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/b6751da5-2e81-4be3-af8b-95cb60faaa3e",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/e1615934-d188-4994-981a-036e5216b156",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "abcd1234",
+        "updated": "2017-03-07T15:27:58Z",
+        "user_id": "efgh5678"
+      }
+    },
+    "sequence_number": 170,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestDiscoverCreate.test_partial.json
+++ b/.test_openstack_TestDiscoverCreate.test_partial.json
@@ -1,0 +1,469 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "bad_foobar_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/bad_foobar_id",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/bad_foobar_id",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/bad_foobar_id",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "AUTO",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "error",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b5:ca:67",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "8.8.8.8",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T20:43:20Z",
+        "fault": {
+          "code": 500,
+          "created": "2017-03-07T20:43:27Z",
+          "message": "Big error message"
+        },
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "bignumber",
+        "id": "bad_foobar_id",
+        "image": {
+          "id": "image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/bad_foobar_id",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/bad_foobar_id",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ERROR",
+        "tenant_id": "tenant_id",
+        "updated": "2017-03-07T20:43:26Z",
+        "user_id": "user_id"
+      }
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "bad_foobar_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/bad_foobar_id",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/bad_foobar_id",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+  {
+    "DELETE": "http://1.2.3.4/servers/bad_foobar_id",
+    "sequence_number": 30
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+          "links": [
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "some_server"
+        }
+      ]
+    },
+    "sequence_number": 40,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/flavors",
+    "response": {
+      "flavors": [
+        {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "self"
+            },
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "m1.medium"
+        }
+      ]
+    },
+    "sequence_number": 50,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2/images?name=CentOS-Cloud-7&status=active",
+    "response": {
+      "first": "/v2/images?status=active&name=CentOS-Cloud-7",
+      "images": [
+        {
+          "architecture": "x86_64",
+          "checksum": "c2ebde45f03aa35c6d996c3de984a9d6",
+          "container_format": "bare",
+          "created_at": "2017-01-04T17:13:31Z",
+          "description": "https://wiki.centos.org/Download",
+          "disk_format": "qcow2",
+          "file": "/v2/images/centos_image_id/file",
+          "id": "centos_image_id",
+          "min_disk": 0,
+          "min_ram": 0,
+          "name": "CentOS-Cloud-7",
+          "owner": "tenant_id",
+          "protected": true,
+          "schema": "/v2/schemas/image",
+          "self": "/v2/images/centos_image_id",
+          "size": 898236416,
+          "status": "active",
+          "tags": [],
+          "updated_at": "2017-01-04T17:14:55Z",
+          "virtual_size": null,
+          "visibility": "private"
+        }
+      ],
+      "schema": "/v2/schemas/images"
+    },
+    "sequence_number": 60,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "adminPass": "",
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "bookmark"
+          }
+        ],
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ]
+      }
+    },
+    "sequence_number": 70,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": "scheduling",
+        "OS-EXT-STS:vm_state": "building",
+        "OS-SRV-USG:launched_at": null,
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {},
+        "config_drive": "",
+        "created": "2017-03-07T20:44:13Z",
+        "hostId": "",
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "progress": 0,
+        "status": "BUILD",
+        "tenant_id": "tenant_id",
+        "updated": "2017-03-07T20:44:13Z",
+        "name": "foobar",
+        "user_id": "user_id"
+      }
+    },
+    "sequence_number": 90,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T20:44:27.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:5c:ab:37",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "2.3.4.5",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T20:44:13Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "39d4a5e9ea77f31a399c20189c24e62c83184be93daa1775576756b3",
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "image": {
+          "id": "centos_image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/centos_image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "tenant_id",
+        "updated": "2017-03-07T20:44:27Z",
+        "user_id": "user_id"
+      }
+    },
+    "sequence_number": 410,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/routers",
+    "response": {
+      "routers": [
+        {
+          "admin_state_up": true,
+          "external_gateway_info": {
+            "enable_snat": true,
+            "external_fixed_ips": [
+              {
+                "ip_address": "3.4.5.6",
+                "subnet_id": "subnet_id"
+              }
+            ],
+            "network_id": "network_name_id"
+          },
+          "id": "8f660c43-3a6f-4ee9-97a9-e3f2fda9fd32",
+          "name": "network_name",
+          "routes": [],
+          "status": "ACTIVE",
+          "tenant_id": "tenant_id"
+        }
+      ]
+    },
+    "sequence_number": 420,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/floatingips",
+    "response": {
+      "floatingips": [
+        {
+          "fixed_ip_address": null,
+          "floating_ip_address": "6.5.4.3",
+          "floating_network_id": "network_name_id",
+          "id": "44608161-678a-49cf-b1d5-fc4535910fbf",
+          "port_id": null,
+          "router_id": null,
+          "status": "DOWN",
+          "tenant_id": "tenant_id"
+        }
+      ]
+    },
+    "sequence_number": 430,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06/action"
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-AZ:availability_zone": "nova",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-03-07T20:44:27.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:5c:ab:37",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "2.3.4.5",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:5c:ab:37",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.5.4.3",
+              "version": 4
+            }
+          ]
+        },
+        "config_drive": "",
+        "created": "2017-03-07T20:44:13Z",
+        "flavor": {
+          "id": "3",
+          "links": [
+            {
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "hostId": "39d4a5e9ea77f31a399c20189c24e62c83184be93daa1775576756b3",
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "image": {
+          "id": "centos_image_id",
+          "links": [
+            {
+              "href": "http://1.2.3.4/images/centos_image_id",
+              "rel": "bookmark"
+            }
+          ]
+        },
+        "key_name": null,
+        "links": [
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "self"
+          },
+          {
+            "href": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+            "rel": "bookmark"
+          }
+        ],
+        "metadata": {},
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "security_groups": [
+          {
+            "name": "default"
+          }
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "tenant_id",
+        "updated": "2017-03-07T20:44:27Z",
+        "user_id": "user_id"
+      }
+    },
+    "sequence_number": 440,
+    "status_code": 200
+  }
+]

--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,19 @@ Prerequisites
 *  Ansible_ 2.1 or later
 *  Root access **not** required
 
+Openstack support:
+-------------------
+
+* redhat-rpm-config (rpm)
+* python-virtualenv or python2-virtualenv (EPEL rpm)
+* `Openstack client config credentials`_
+
 .. _Ansible: http://docs.ansible.com/index.html
 .. _RHEL: http://www.redhat.com/rhel
 .. _Atomic: http://www.redhat.com/en/resources/red-hat-enterprise-linux-atomic-host
 .. _CentOS: http://www.centos.org
 .. _Fedora: http://www.fedoraproject.org
+.. _`Openstack client config credentials`: https://docs.openstack.org/developer/os-client-config/
 
 Quickstart
 ===========

--- a/exekutir/inventory/group_vars/openstack/all.yml
+++ b/exekutir/inventory/group_vars/openstack/all.yml
@@ -4,16 +4,18 @@
 
 cloud_asserts:
     - 'kommandir_name is defined'
-    - 'workspace is defined'
-    - 'kommandir_workspace is defined'
+    - 'hostvars.exekutir.workspace is defined'
+    - 'hostvars.exekutir.kommandir_workspace is defined'
+    # Somehow, somewhere, this file must be made to exist inside workspace
     - 'lookup("pipe","test -r $WORKSPACE/clouds.yml; echo $?) == "0"'
-    - 'lookup("pipe","test -r ${ANSIBLE_PRIVATE_KEY_FILE}; echo $?) == "0"'
-    - 'lookup("pipe","test -r ${ANSIBLE_PRIVATE_KEY_FILE}.pub; echo $?) == "0"'
+    # These two are guaranteed by exekutir.xn
+    - 'lookup("pipe","test -r {{ hostvars.exekutir.workspace }}/ssh/exekutir_key; echo $?) == "0"'
+    - 'lookup("pipe","test -r {{ hostvars.exekutir.workspace }}/ssh/exekutir_key.pub; echo $?) == "0"'
 
 cloud_provisioning_command:
-    command: "{{ kommandir_workspace }}/bin/openstack_discover_create.py {{ uuid }} {{ kommandir_name }} ${ANSIBLE_PRIVATE_KEY_FILE} ${ANSIBLE_PRIVATE_KEY_FILE}.pub"
+    command: "{{ kommandir_workspace }}/bin/openstack_discover_create.py {{ kommandir_name }} {{ hostvars.exekutir.workspace }}/ssh/exekutir_key.pub {{ extra_ssh_pub_keys | join(' ') if extra_ssh_pub_keys is defined else omit }}"
     chdir: "{{ workspace }}"
 
 cloud_destruction_command:
-    command: "{{ kommandir_workspace }}/bin/openstack_destroy.py {{ uuid }} {{ kommandir_name }} ${ANSIBLE_PRIVATE_KEY_FILE} ${ANSIBLE_PRIVATE_KEY_FILE}.pub"
+    command: "{{ kommandir_workspace }}/bin/openstack_destroy.py {{ kommandir_name }}
     chdir: "{{ workspace }}"

--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python2
+
+"""
+ADEPT VM provisioning / cleanup script for the openstack ansible group.
+
+Assumed to be running under an exclusive lock to prevent TOCTOU race
+and/or clashes with existing named VMs.
+
+Requires:
+*  RHEL/CentOS/Fedora host w/ RPMs:
+    * redhat-rpm-config (base)
+    * python-virtualenv or python2-virtualenv (EPEL)
+* Openstack credentials as per:
+    https://docs.openstack.org/developer/os-client-config/
+* Execution under adept.py exekutir.xn transition file or unittests
+"""
+
+import sys
+import os
+import os.path
+import logging
+import subprocess
+import time
+from base64 import b64encode
+
+# Placeholder, will be set by unittests or under if __name__ == '__main__'
+os_client_config = ValueError  # pylint: disable=C0103
+
+# Lock-down versions of os-client-config and all dependencies for stability
+PIP_REQUIREMENTS = [
+    'os-client-config==1.21.1',
+    'appdirs==1.4.2',
+    'iso8601==0.1.11',
+    'keystoneauth1==2.18.0',
+    'os-client-config==1.21.1',
+    'pbr==1.10.0',
+    'positional==1.1.1',
+    'PyYAML==3.12',
+    'requests==2.13.0',
+    'requestsexceptions==1.1.3',
+    'six==1.10.0',
+    'stevedore==1.20.0',
+    'wrapt==1.10.8']
+# No C/C++ compiler is available in this virtualenv
+PIP_ONLY_BINARY = [':all:']
+# These must be compiled, but don't require C/C++
+PIP_NO_BINARY = ['wrapt', 'PyYAML', 'positional']
+
+IMAGE = 'CentOS-Cloud-7'
+FLAVOR = 'm1.medium'
+
+# Exit code to return when --help output is displayed (for unitesting)
+HELP_EXIT_CODE = 127
+
+# Operation is discovered by symlink name used to execute script
+DISCOVER_CREATE_NAME = 'openstack_discover_create.py'
+DESTROY_NAME = 'openstack_destroy.py'
+
+OUTPUT_FORMAT = """---
+inventory_hostname: {name}
+ansible_host: {floating_ip}
+ansible_ssh_host: {{{{ ansible_host }}}}
+"""
+
+class OpenstackREST(object):
+    """
+    State full cache of Openstack REST API interactions.
+
+    :docs: https://developer.openstack.org/#api
+    """
+
+    # The singleton
+    _self = None
+
+    # Cache of current and previous response instances and json() return.
+    response_json = None
+    response_obj = None
+    # Useful for debugging purposes
+    previous_responses = None
+
+    # Current session object
+    service_sessions = None
+
+    def __new__(cls, service_sessions=None):
+        if cls._self is None:  # Initialize singleton
+            if service_sessions is None:
+                raise ValueError("service_sessions must be passed the first time")
+            cls._self = super(OpenstackREST, cls).__new__(cls)
+            cls.service_sessions = service_sessions
+            cls.previous_responses = []
+        return cls._self  # return singleton
+
+    def raise_if(self, true_condition, xception, msg):
+        """
+        If true_condition, throw xception with additional msg.
+        """
+        if not true_condition:
+            return None
+
+        if self.previous_responses:
+            responses = self.previous_responses + [self.response_obj]
+        elif self.response_obj:
+            responses = [self.response_obj]
+        else:
+            responses = []
+
+        logging.debug("Response History:")
+        for response in responses:
+            logging.debug('  (%s) %s:', response.request.method, response.request.url)
+            try:
+                logging.debug('    %s', response.json())
+            except ValueError:
+                pass
+            logging.debug('')
+
+        if callable(xception):  # Exception not previously raised
+            xcept_class = xception
+            xcept_value = xception(msg)
+            xcept_traceback = None   # A stack trace would be nice here
+            raise xcept_class, xcept_value, xcept_traceback
+        else:  # Exception previously raised, re-raise it.
+            raise
+
+    def service_request(self, service, uri, unwrap=None, method='get', post_json=None):
+        """
+        Make a REST API call to uri, return optionally unwrapped json instance.
+
+        :param service: Name of service to request uri from
+        :param uri: service URI for get, post, delete operation
+        :param unwrap: Optional, unwrap object name from response
+        :param method: Optional, http method to use, 'get', 'post', 'delete'.
+        :param post_json: Optional, json instance to send with post method
+        :raise ValueError: If request was unsuccessful
+        :raise KeyError: If unwrap key does not exist in response_json
+        :returns: json instance
+        """
+        session = self.service_sessions[service]
+        if self.response_obj is not None:
+            self.previous_responses.append(self.response_obj)
+        if method == 'get':
+            self.response_obj = session.get(uri)
+        elif method == 'post':
+            self.response_obj = session.post(uri, json=post_json)
+        elif method == 'delete':
+            self.response_obj = session.delete(uri)
+        else:
+            self.raise_if(True,
+                          ValueError,
+                          "Unknown method %s" % method)
+
+        code = int(self.response_obj.status_code)
+        self.raise_if(code not in [200, 201, 202, 204],
+                      ValueError, "Failed: %s request to %s: %s" % (method, uri, code))
+
+        try:
+            self.response_json = self.response_obj.json()
+        except ValueError:  # Not every request has a JSON response
+            self.response_json = None
+
+        # All responses encode the object under it's name.
+        if unwrap:
+            self.raise_if(unwrap not in self.response_json,
+                          KeyError, "No %s in json: %s"
+                          % (unwrap, self.response_json))
+            self.response_json = self.response_json[unwrap]
+            return self.response_json
+        else:  # return it as-is
+            return self.response_json
+
+    def compute_request(self, uri, unwrap=None, method='get', post_json=None):
+        """
+        Short-hand for ``service_request('compute', uri, unwrap, method, post_json)``
+        """
+        return self.service_request('compute', uri, unwrap, method, post_json)
+
+    def child_search(self, key, value=None, alt_list=None):
+        """
+        Search cached, or alt_list for object with key, or key set to value.
+
+        :param key: String, the key to search for, return list of values.
+        :param value: Optional, required value for key, first matching item.
+        :param alt_list: Optional, search this instance instead of cache
+        :raises TypeError: If self.response_json or alt_json are None
+        :raises ValueError: If self.response_json or alt_json are empty
+        :raises IndexError: If no item has key with value
+        """
+        if alt_list is not None:
+            search_list = alt_list
+        else:
+            search_list = self.response_json
+
+        self.raise_if(search_list is None,
+                      TypeError, "No requests have been made/cached")
+
+        if value:
+            found = [child for child in search_list
+                     if child.get(key) == value]
+            try:
+                return found[0]
+            except IndexError, xcept:
+                self.raise_if(True,
+                              xcept,
+                              'Could not find key %s with value %s in %s'
+                              % (key, value, search_list))
+        else:
+            found = [child[key] for child in search_list
+                     if key in child]
+            self.raise_if(not found,
+                          IndexError,
+                          'Could not find key %s in %s'
+                          % (key, search_list))
+            return found
+
+    def server_list(self):
+        """
+        Cache and return list of server names or empty list
+
+        :returns: list of strings
+        """
+        self.compute_request('/servers', 'servers')
+        try:
+            return self.child_search('name')
+        except IndexError:
+            return []
+
+    def server(self, name=None, uuid=None):
+        """
+        Cache and return details about server name or uuid
+
+        :param name: Optional, exclusive of uuid, name of server
+        :param uuid: Optional, exclusive of name, ID of server
+        :returns: dictionary of server details
+        """
+        self.raise_if(not name and not uuid,
+                      ValueError,
+                      "Must provide either name or uuid")
+        if name:
+            self.compute_request('/servers', 'servers')
+            server_details = self.child_search(key='name', value=name)
+            uri = '/servers/%s' % server_details['id']
+        elif uuid:
+            uri = '/servers/%s' % uuid
+        return self.compute_request(uri, unwrap='server')
+
+
+    def server_ip(self, name=None, uuid=None):
+        """
+        Cache details about server, return floating ip address of server
+
+        :param name: Optional, name of server to retrieve IP from
+        :param uuid: Optional, ID of server to retrieve IP from
+        :returns: IPv4 address for server or None if none are assigned
+        """
+        self.server(name=name, uuid=uuid)
+        networks = self.response_json['addresses'].keys()
+        self.raise_if(len(networks) > 1,
+                      ValueError,
+                      "Found %s to be on more than one network" % name)
+        self.raise_if(len(networks) == 0,
+                      ValueError,
+                      "Found %s to be on no networks" % name)
+        try:
+            ifaces = self.response_json['addresses'][networks[0]]
+            floating_iface = self.child_search('OS-EXT-IPS:type', 'floating',
+                                               alt_list=ifaces)
+            return floating_iface['addr']
+        except (KeyError, IndexError), xcept:
+            self.raise_if(True,
+                          xcept,
+                          "Found %s to be on a network"
+                          " without a floating IP address" % name)
+
+    def server_delete(self, name=None, uuid=None):
+        """
+        Cache list of servers, try to delete server by name or uuid
+
+        :param name: Optional, name of server to retrieve IP from
+        :param uuid: Optional, ID of server to retrieve IP from
+        :returns: True if server delete request successful
+        """
+        try:
+            server_details = self.server(name=name, uuid=uuid)
+        except IndexError:
+            return True # Server doesn't exist
+        try:
+            self.compute_request('/servers/%s' % server_details['id'],
+                                 method='delete')
+            return True
+        # This can fail for any number of reasons, can't list them all
+        # pylint: disable=W0702
+        except:
+            return False
+
+    def floating_ip(self):
+        """
+        Cache list of floating IPs, return first un-assigned or None
+
+        :returns: IP address string or None
+        """
+        self.service_request('network', '/v2.0/floatingips', 'floatingips')
+        try:
+            return self.child_search('status', value='DOWN')["floating_ip_address"]
+        except (KeyError, IndexError):
+            return None
+
+class TimeoutAction(object):  # pylint: disable=R0903
+    """
+    ABC callable, raises an exception on timeout, or returns non-None value of done()
+    """
+
+    sleep = 0.1  # Sleep time per iteration, avoids busy-waiting.
+    timeout = 300.0  # (seconds)
+    time_out_at = None  # absolute
+    timeout_exception = RuntimeError
+
+    def __init__(self, *args, **dargs):
+        """
+        Initialize instance, perform initial actions, timeout checking on call.
+
+        :param *args: (Optional) list of positional arguments to pass to am_done()
+        :param **dargs: (Optional) dictionary of keyword arguments to pass to am_done()
+        """
+        self._args = args
+        self._dargs = dargs
+
+    def __str__(self):
+        return ("%s(*%s, **%s) after %0.2f"
+                % (self.__class__.__name__, self._args, self._dargs, self.timeout))
+
+    def __call__(self):
+        """
+        Repeatedly call ``am_done()`` until timeout or non-None return
+        """
+        result = None
+        start = time.time()
+        if self.time_out_at is None:
+            self.time_out_at = start + self.timeout
+        while result is None:
+            if time.time() >= self.time_out_at:
+                raise self.timeout_exception(str(self))
+            time.sleep(self.sleep)
+            result = self.am_done(*self._args, **self._dargs)
+        return result
+
+    def am_done(self, *args, **dargs):
+        """
+        Abstract method, must return non-None to stop iterating
+        """
+        raise NotImplementedError
+
+
+class TimeoutDeleted(TimeoutAction):
+    """Helper class to ensure server is deleted within timeout window"""
+
+    timeout = 60
+
+    def __init__(self, name):
+        super(TimeoutDeleted, self).__init__(name)
+        self.os_rest = OpenstackREST()
+        self.os_rest.server_delete(name)
+
+    def am_done(self, name):
+        """Return Non-None if server does not appear in server list"""
+        if name not in self.os_rest.server_list():
+            return name
+        else:
+            return None
+
+
+class TimeoutCreate(TimeoutAction):
+    """Helper class to ensure server creation and state within timeout window"""
+
+    timeout = 120
+
+    POWERSTATES = {
+        0: 'NOSTATE',
+        1: 'RUNNING',
+        3: 'PAUSED',
+        4: 'SHUTDOWN',
+        6: 'CRASHED',
+        7: 'SUSPENDED'}
+
+    def __init__(self, name, auth_key_lines):
+        super(TimeoutCreate, self).__init__(name, auth_key_lines)
+        self.os_rest = OpenstackREST()
+
+        self.os_rest.compute_request('/flavors', 'flavors')
+        flavor = self.os_rest.child_search('name', FLAVOR)
+        logging.debug("Flavor %s is id %s", FLAVOR, flavor['id'])
+
+        # Faster for the server to search for this
+        image = self.os_rest.service_request('image',
+                                             '/v2/images?name=%s&status=active' % IMAGE,
+                                             'images')
+        # Validates only one image was found, not really searching
+        image = self.os_rest.child_search('name', IMAGE)
+        logging.debug("Image %s is id %s", IMAGE, image['id'])
+
+        user_data = ("#cloud-config\n"
+                     # Because I'm self-centered
+                     "timezone: US/Eastern\n"
+                     # We will configure our own filesystems/partitioning
+                     "growpart:\n"
+                     "    mode: off\n"
+                     # Don't add silly 'please login as' to .ssh/authorized_keys
+                     "disable_root: false\n"
+                     # Allow password auth in case it's needed
+                     "ssh_pwauth: True\n"
+                     # Import all ssh_authorized_keys (below) into these users
+                     "ssh_import_id: [root]\n"
+                     # public keys to import to users (above)
+                     "ssh_authorized_keys: %s\n"
+                     # Prevent creating the default, generic user
+                     "users:\n"
+                     "   - name: root\n"
+                     "     primary-group: root\n"
+                     "     homdir: /root\n"
+                     "     system: true\n" % auth_key_lines)
+        logging.debug("Userdata: %s", user_data)
+
+        server_json = dict(
+            name=name,
+            flavorRef=flavor['id'],
+            imageRef=image['id'],
+            user_data=b64encode(user_data)
+        )
+        logging.info("Submitting creation request")
+        self.os_rest.compute_request('/servers', 'server',
+                                     'post', post_json=dict(server=server_json))
+        self.server_id = self.os_rest.response_json['id']
+
+    def am_done(self, name, auth_key_lines):
+        """Return VM's UUID if is active and powered up, None otherwise"""
+        del auth_key_lines  # Not needed here
+        server_details = self.os_rest.server(uuid=self.server_id)
+        vm_state = server_details['OS-EXT-STS:vm_state']
+        power_state = self.POWERSTATES.get(server_details['OS-EXT-STS:power_state'],
+                                           'UNKNOWN')
+        logging.info("     %s: %s, power %s", name, vm_state, power_state)
+        if power_state == 'RUNNING' and vm_state == 'active':
+            return self.server_id
+        else:
+            return None
+
+
+class TimeoutAssignFloatingIP(TimeoutAction):
+    """Helper class to ensure floating IP assigned to server within timeout window"""
+
+    timeout = 30
+
+    def __init__(self, server_id):
+        super(TimeoutAssignFloatingIP, self).__init__(server_id)
+        self.os_rest = OpenstackREST()
+
+        routers = self.os_rest.service_request('network', '/v2.0/routers', "routers")
+        # Assume the first router is the one to use
+        gw_info = routers[0]['external_gateway_info']
+        self.floating_network_id = gw_info['network_id']
+        logging.debug("Router %s network id %s for server id %s",
+                      routers[0]['name'],
+                      self.floating_network_id,
+                      server_id)
+
+    def am_done(self, server_id):
+        """Return assigned floating IP for server or None"""
+        floating_ip = self.os_rest.floating_ip()  # Get dis-used IP
+        if not floating_ip:
+            logging.info("Creating new floating IP address on network %s",
+                         self.floating_network_id)
+            floatingip = dict(floating_network_id=self.floating_network_id)
+
+            self.os_rest.service_request('network', '/v2.0/floatingips',
+                                         "floatingip", method='post',
+                                         post_json=dict(floatingip=floatingip))
+            floating_ip = self.os_rest.response_json['floating_ip_address']
+        else:
+            logging.info("Found disused ip %s", floating_ip)
+
+        logging.info("Attempting to assign floating IP %s to server id %s",
+                     floating_ip, server_id)
+        try:
+            addfloatingip = dict(address=floating_ip)
+            self.os_rest.compute_request('/servers/%s/action' % server_id,
+                                         unwrap=None, method='post',
+                                         post_json=dict(addFloatingIp=addfloatingip))
+            self.os_rest.server_ip(uuid=server_id)
+            return floating_ip
+        except (ValueError, KeyError, IndexError):
+            logging.info("Assignment failed, retrying")
+            return None
+
+
+
+def create(name, pub_key_files):
+    """
+    Create a new VM with name and authorized_keys containing pub_key_files.
+
+    :param name: Name of the VM to create
+    :param pub_key_files: List of ssh public key files to read
+    """
+
+    pubkeys = []
+    for pub_key_file in pub_key_files:
+        logging.debug("Loading public key file: %s", pub_key_file)
+        with open(pub_key_file, 'rb') as key_file:
+            pubkeys.append(key_file.read().strip())
+            if 'PRIVATE KEY' in pubkeys[-1]:
+                raise ValueError("File %s appears to be a private, not a public, key"
+                                 % pub_key_file)
+    logging.info("Deleting any partially created VM %s", name)
+    TimeoutDeleted(name)()
+
+    try:
+        server_id = TimeoutCreate(name, pubkeys)()
+        logging.info("Creation successful, attempting to assign floating ip to VM %s", name)
+        floating_ip = TimeoutAssignFloatingIP(server_id)()
+        logging.info("Floating IP assignment successful, ip %s", floating_ip)
+    except:
+        # Fire and forget
+        os_rest = OpenstackREST()
+        os_rest.server_delete(name)
+        raise
+    sys.stdout.write(OUTPUT_FORMAT.format(name=name, floating_ip=floating_ip))
+
+
+def discover(name, pub_key_files=None):
+    """
+    Write ansible host_vars to stdout if a VM name exists with a floating IP.
+
+    :param name: Name of the VM to search for
+    :param pub_key_files: Not used
+    """
+    # Allows earlier CLI parameter error detection
+    del pub_key_files
+
+    os_rest = OpenstackREST()
+    # Server is useless if it can't be reached
+    floating_ip = os_rest.server_ip(name)
+
+    sys.stdout.write(OUTPUT_FORMAT.format(name=name, floating_ip=floating_ip))
+
+
+def destroy(name):
+    """
+    Destroy VM name
+
+    :param name: Name of the VM to destroy
+    """
+    TimeoutDeleted(name)()
+
+
+def parse_args(argv, operation):
+    """
+    Examine command line arguments, show usage info if inappropriate for operation
+
+    :param argv: List of command-line arguments
+    :param operation: String of 'discover', 'create', or 'destroy'
+    :returns: Dictionary of parsed command-line options
+    """
+    # N/B argv[0] is path to executed command
+    argv = argv[1:]
+    try:
+        parsed_args = dict(name=argv.pop(0))
+    except IndexError:
+        raise ValueError("Must pass server name as first parameter")
+    if operation in ['create', 'discover']:
+        if len(argv) < 1:
+            raise ValueError("Must pass server name, and one or more"
+                             " paths to public ssh key files as parameters")
+        parsed_args['pub_key_files'] = set(argv)
+    elif operation == 'help':
+        logging.info("FIXME: Some useful --help message")
+    elif operation not in ('discover', 'destroy'):
+        raise ValueError("Unknown operation operation %s, pass --help for help.",
+                         operation)
+    return parsed_args
+
+
+def pip_opt_arg(option, arg_list, delim=','):
+    """
+    If arg_list is non-empty, return option string with args separated by delim.
+    """
+    if arg_list:
+        if option:
+            return '%s %s' % (option, delim.join(arg_list))
+        else:
+            return '%s' % delim.join(arg_list)
+    else:
+        return ''
+
+
+def activate_virtualenv():
+    """
+    Setup and use a virtualenv from $WORKSPACE with required dependencies
+    """
+    shell = lambda cmd: subprocess.check_call(cmd, close_fds=True, shell=True,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.STDOUT)
+    venvdir = os.path.join(os.environ['WORKSPACE'], '.virtualenv')
+    logging.info("Setting up python virtual environment under %s", venvdir)
+    if not os.path.isdir(venvdir):
+        shell('virtualenv -p /usr/bin/python2.7 %s' % venvdir)
+    # Setup dependencies in venvdir to keep host dependencies low
+    activate_this = os.path.join(venvdir, 'bin', 'activate_this.py')
+    logging.debug("Activating python virtual environment")
+    execfile(activate_this, dict(__file__=activate_this))
+    logging.info("Upgrading pip (inside virtual environment)")
+    shell('pip install --upgrade pip')
+    logging.info("Installing dependencies (inside virtual environment)")
+    shell('pip install %s %s %s'
+          % (pip_opt_arg('--only-binary', PIP_ONLY_BINARY),
+             pip_opt_arg('--no-binary', PIP_NO_BINARY),
+             pip_opt_arg('', PIP_REQUIREMENTS, ' ')))
+    logging.info("Reactivating python virtual environment")
+    execfile(activate_this, dict(__file__=activate_this))
+
+
+def main(argv, service_sessions):
+    """
+    Contains all primary calls for script for easier unit-testing
+
+    :param argv: List of command-line arguments, e.g. sys.argv
+    :param service_sessions: Mapping of service names
+                             to request-like session instances
+    :returns: Exit code integer
+    """
+    _ = OpenstackREST(service_sessions)
+    basename = os.path.basename(argv[0])
+    if basename == DISCOVER_CREATE_NAME:
+        dargs = parse_args(argv, 'discover')
+        logging.info('Attempting to find VM %s.', dargs['name'])
+        # The general exception is re-raised on secondary exception
+        # pylint: disable=W0703
+        try:
+            discover(**dargs)
+        except Exception, xcept:
+            # Not an error (yet), will try creating VM next
+            logging.warning("Failed to find existing VM: %s.", dargs['name'])
+            try:
+                dargs = parse_args(argv, 'create')
+                logging.info('Attempting to create new VM %s.', dargs['name'])
+                create(**dargs)
+            except:
+                logging.error("Original discovery-exception,"
+                              " creation exception follows:")
+                logging.error(xcept)
+                logging.error("Creation exception:")
+                raise
+    elif basename == DESTROY_NAME:
+        dargs = parse_args(argv, 'destroy')
+        logging.info("Destroying VM %s", dargs['name'])
+        destroy(**dargs)
+    else:
+        parse_args(argv, 'help')
+
+
+def api_debug_dump():
+    """Dump out all API request responses into a file in virtualenv dir"""
+    lines = []
+    os_rest = OpenstackREST()
+    seq_num = 0
+    for response in os_rest.previous_responses + [os_rest.response_obj]:
+        try:
+            lines.append({response.request.method: response.request.url})
+            lines[-1]['response'] = response.json()
+            lines[-1]['status_code'] = response.status_code
+            # These are useful for creating unitest data + debugging unittests
+            lines[-1]['sequence_number'] = seq_num
+            seq_num += 10
+        except ValueError:
+            pass
+    basename = os.path.basename(sys.argv[0])
+    prefix = basename.split('.', 1)[0]
+    filepath = os.path.join(os.environ['WORKSPACE'], '.virtualenv',
+                            '%s_api_responses.json' % prefix)
+    logging.info("Recording all response JSONs into: %s", filepath)
+    # Don't fail main operations b/c missing module
+    import simplejson
+    with open(filepath, 'wb') as debugf:
+        simplejson.dump(lines, debugf, indent=2, sort_keys=True)
+
+if __name__ == '__main__':
+    LOGGER = logging.getLogger()
+    # Lower default to INFO level and higher
+    if [arg for arg in sys.argv if arg == '-v']:
+        sys.argv.remove('-v')
+        LOGGER.setLevel(logging.DEBUG)
+    else:
+        LOGGER.setLevel(logging.INFO)
+    del LOGGER  # no longer needed
+    # N/B: Any/All names used here are in the global scope
+    # pylint: disable=C0103
+    if 'WORKSPACE' not in os.environ:
+        raise RuntimeError("Environment variable WORKSPACE is not set,"
+                           " it must be a temporary, writeable directory.")
+
+    activate_virtualenv()
+    # Import module from w/in virtual environment into global namespace
+    os_client_config = __import__('os_client_config', globals(), locals())
+
+    config = os_client_config.get_config()
+    sessions = dict([(svc, os_client_config.make_rest_client(svc))
+                     for svc in config.get_services()])
+    main(sys.argv, sessions)
+
+    try:
+        api_debug_dump()
+    # This is just for debugging, ignore all errors
+    # pylint: disable=W0702
+    except:
+        pass

--- a/kommandir/bin/openstack.py
+++ b/kommandir/bin/openstack.py
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-
-

--- a/kommandir/bin/openstack_destroy.py
+++ b/kommandir/bin/openstack_destroy.py
@@ -1,1 +1,1 @@
-openstack.py
+adept_openstack.py

--- a/kommandir/bin/openstack_discover_create.py
+++ b/kommandir/bin/openstack_discover_create.py
@@ -1,1 +1,1 @@
-openstack.py
+adept_openstack.py

--- a/test_openstack.py
+++ b/test_openstack.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python
+
+"""
+Unittests for adept module
+
+Dependencies:
+    - python-2.7
+    - python-unittest2
+    - python-mock
+    - pylint
+    - python-jenkins
+    - test_adept
+"""
+
+import sys
+import simplejson
+from urlparse import urlparse
+from urlparse import urlunparse
+import unittest2 as unittest
+import test_adept
+# ref: http://www.voidspace.org.uk/python/mock/index.html
+from mock import Mock
+from mock import mock_open
+from mock import patch
+
+# For test discovery all test modules must be importable from the top level
+# directory of the project.  No clean way to do this that doesn't depend on
+# knowledge of the repo directory structure somewhere/somehow.
+UUT_REL_PATH = 'kommandir/bin/'
+sys.path.insert(0, UUT_REL_PATH)
+
+# For internal unittest use, don't care about too-few-public methods
+# pylint: disable=R0903
+class FakeSession(object):
+    """
+    Standin for a rest API session that responds with predetermined data
+    """
+
+    # List of Mock response objects containing requests with uri and method
+    resp_mocks = None
+
+    # List of Mock response objects that were returned successfully
+    found_mocks = None
+
+    @staticmethod
+    def _xform_uri(uri):
+        """
+        Enforce uniform test URIs by rewriting method and netloc components
+        """
+        (_, _, path,
+         parameters, query, fragment) = urlparse(uri)
+        # Always modified for testing purposes
+        return urlunparse(('http', '1.2.3.4', path,
+                           parameters, query, fragment))
+
+    def __init__(self, resp_filename=''):
+        """
+        Setup instance to respond with mocks based on ``api_debug_dump()`` output
+        """
+        self.resp_filename = resp_filename
+        self.resp_mocks = []
+        self.found_mocks = []
+        if not resp_filename:
+            return
+        with open(self.resp_filename, 'rb') as resp_file:
+            for resp_obj in simplejson.load(resp_file):
+                resp = Mock()
+                resp.json = Mock(return_value=resp_obj.pop('response', None))
+                resp.status_code = resp_obj.pop('status_code', 200)
+                resp.sequence_number = resp_obj.pop('sequence_number', -1)
+                resp.request = Mock()  # as openstack session api does it
+                # Remaining key is method, value is uri
+                assert len(resp_obj) == 1  # bad file format
+                resp.request.method = str(resp_obj.keys()[0])
+                resp.request.uri = self._xform_uri(resp_obj.pop(resp.request.method))
+                self.resp_mocks.append(resp)
+
+    def find_mock(self, method, uri, json=None):
+        """
+        Return mock object cooresponding to a request for uri with method
+        """
+        del json  # not used
+        uri = self._xform_uri(uri)
+        for index, response in enumerate(self.resp_mocks):
+            if method.lower() != response.request.method.lower():
+                continue
+            if uri != response.request.uri:
+                continue
+            # List is ordered, record, remove and return first match
+            self.found_mocks.append(self.resp_mocks.pop(index))
+            return self.found_mocks[-1]
+        if not self.found_mocks:
+            seq_no = None
+        else:
+            seq_no = self.found_mocks[-1].sequence_number
+        msg = ("No response found for %s request of %s"
+               " Previous entry sequence number %s"
+               % (method, uri, seq_no))
+        raise KeyError(msg)
+
+    get = lambda self, uri: self.find_mock('GET', uri)
+    post = lambda self, uri, json: self.find_mock('POST', uri, json)
+    delete = lambda self, uri: self.find_mock('DELETE', uri)
+
+
+# For internal unittest use, don't care about too-few-public methods
+# pylint: disable=R0903
+class FakeServiceSessions(object):
+    """Standin for service_sessions dictionary, ignores the service nmae"""
+
+    def __init__(self, fake_session):
+        self.fake_session = fake_session
+
+    def __getitem__(self, key):
+        del key
+        return self.fake_session
+
+    def __contains__(self, key):
+        del key
+        return True
+
+
+class TestCaseBase(test_adept.TestCaseBase):
+    """Reuses essental/basic unittest plumbing from adepts unittests"""
+
+    UUT = 'adept_openstack'
+
+    def setUp(self):
+        super(TestCaseBase, self).setUp()
+        self.uut = __import__(self.UUT)
+
+
+class TestPylint(test_adept.TestPylint):
+    """Reuses essental pyline-plumbing from adepts unittests, for this module"""
+
+    UUT = TestCaseBase.UUT
+
+    DISABLE = test_adept.TestPylint.DISABLE + ',W0221,R0903'
+
+    def test_unittest_pylint(self):
+        "Run pylint on the unittest module itself"
+        self._pylintrun(__file__)
+
+    def test_uut_pylint(self):
+        "Run pylint on the unit under test"
+        self._pylintrun(self.uut.__file__)
+
+
+class TestParsedArgs(TestCaseBase):
+    """Tests of parse_args function"""
+
+    def test_operations(self):
+        """Check expected arguments come from parsed_args"""
+        op_argv = dict(destroy=['self', 'foo',],
+                       create=['self', 'foo', 'bar', 'baz'],
+                       discover=['self', 'baz', 'baz', 'bar'])
+        op_expected = dict(destroy=dict(name=op_argv['destroy'][1]),
+                           create=dict(name=op_argv['create'][1],
+                                       pub_key_files=set(op_argv['create'][2:])),
+                           discover=dict(name=op_argv['discover'][1],
+                                         pub_key_files=set(op_argv['discover'][2:])))
+        for opr in ('destroy', 'create', 'discover'):
+            parsed_args = self.uut.parse_args(op_argv[opr], opr)
+            with self.subTest(expected=op_expected[opr], parsed_args=parsed_args):
+                self.assertDictContainsSubset(op_expected[opr], parsed_args)
+
+
+class TestMain(TestCaseBase):
+    """Test main function"""
+
+    def setUp(self):
+        super(TestMain, self).setUp()
+        self.discover = Mock(spec=self.uut.discover)
+        self.create = Mock(spec=self.uut.create)
+        self.destroy = Mock(spec=self.uut.destroy)
+        self.service_sessions = FakeServiceSessions(FakeSession())
+        self.create_patch('%s.discover' % self.UUT, self.discover)
+        self.create_patch('%s.create' % self.UUT, self.create)
+        self.create_patch('%s.destroy' % self.UUT, self.destroy)
+        self.create_patch('%s.sys.stderr' % self.UUT, None)
+
+    def test_discover(self):
+        """Test main calls discover function"""
+        self.uut.main([self.uut.DISCOVER_CREATE_NAME, 'foobar', 'snafu'],
+                      self.service_sessions)
+        self.assertFalse(self.destroy.called)
+        self.assertFalse(self.create.called)
+        self.assertTrue(self.discover.called)
+
+    def test_create(self):
+        """Test main calls discover then create functions"""
+        # When discovery fails, create is called.
+        self.discover.side_effect = ValueError("Unittest error message")
+        with self.assertLogs(level='WARNING') as context:
+            self.uut.main([self.uut.DISCOVER_CREATE_NAME,
+                           'foobar', 'snafu'],
+                          self.service_sessions)
+        self.assertRegex(' '.join(context.output),
+                         r'.*existing.*%s' % 'foobar')
+        self.assertFalse(self.destroy.called)
+        self.assertTrue(self.discover.called)
+        self.assertTrue(self.create.called)
+
+    def test_destroy(self):
+        """Test main calls destroy function"""
+        self.uut.main([self.uut.DESTROY_NAME, 'snafu', 'foobar'],
+                      self.service_sessions)
+        self.assertFalse(self.create.called)
+        self.assertFalse(self.discover.called)
+        self.assertTrue(self.destroy.called)
+
+
+class TestVirtEnvPlaceholders(TestCaseBase):
+    """Test expected virtualenv module placeholders"""
+
+    def test_os_client_config(self):
+        """Verify os_client_config set to placeholder value"""
+        self.assertIs(ValueError, self.uut.os_client_config)
+
+
+class TestOpenstackREST(TestCaseBase):
+    """Test OpenstackREST class"""
+
+    def setUp(self):
+        super(TestOpenstackREST, self).setUp()
+        self.service_sessions = FakeServiceSessions(FakeSession())
+
+    def test_init(self):
+        """Test init, singleton, and attributes"""
+        first = self.uut.OpenstackREST(self.service_sessions)
+        second = self.uut.OpenstackREST(Mock())
+        for inst in (first, second):
+            self.assertEqual(inst.service_sessions, self.service_sessions)
+            self.assertIsNone(inst.response_json)
+            self.assertIsNone(inst.response_obj)
+            self.assertEqual(inst.previous_responses, [])
+            self.assertIsNotNone(inst.service_sessions)
+
+    def test_child_search(self):
+        """Test expected exceptions/output from child_search)"""
+        whipping_boy = self.uut.OpenstackREST(self.service_sessions)
+        self.assertRaises(TypeError, whipping_boy.child_search, 'foo', 'bar')
+        self.assertRaises(TypeError, whipping_boy.child_search, 'foo', 'bar', None)
+        test_json = [dict(id="foo", data="bar"),
+                     dict(id="sna", data="foo"),
+                     dict(non="conforming")]
+        for whipping_boy.response_json in (None, test_json, 'special'):
+            if whipping_boy.response_json == 'special':
+                whipping_boy.response_json = test_json
+                alt_list = None
+            else:
+                alt_list = test_json
+            self.assertEqual(whipping_boy.child_search('id', alt_list=alt_list),
+                             ['foo', 'sna'])
+            self.assertEqual(whipping_boy.child_search('data', alt_list=alt_list),
+                             ['bar', 'foo'])
+            self.assertEqual(whipping_boy.child_search('non', alt_list=alt_list),
+                             ['conforming'])
+            self.assertEqual(whipping_boy.child_search('id', 'sna', alt_list=alt_list),
+                             test_json[1])
+
+
+class TestDiscoverCreateDestroyBase(TestCaseBase):
+    """Base class for discover, create, and delete testing fixtures"""
+
+    # When non-None, filename prefix + self._testMethodNameto to setup FakeSession()
+    resp_filename_prefix = None
+
+    def setUp(self):
+        super(TestDiscoverCreateDestroyBase, self).setUp()
+        open_stdout = mock_open()
+        self.create_patch('%s.sys.stdout' % self.UUT, [open_stdout('stdout', 'wb')])
+        self.create_patch('%s.sys.stderr' % self.UUT, [open_stdout('stderr', 'wb')])
+        self.stdout = self.uut.sys.stdout
+        self.stderr = self.uut.sys.stderr
+        # Don't actually sleep
+        self.create_patch('%s.time.sleep' % self.UUT, lambda x: None)
+        # Pretend that time is passing
+        self.fake_time_value = 123456
+        self.create_patch('%s.time.time' % self.UUT, self.fake_time)
+        self.create_patch('%s.time.sleep' % self.UUT, self.fake_time)
+        if self.resp_filename_prefix:
+            self.filename = '%s%s.json' % (self.resp_filename_prefix, self._testMethodName)
+            self.fake_session = FakeSession(self.filename)
+            # Un-singleton the singleton
+            self.uut.OpenstackREST._self = None
+            # Initialize singleton with fake sessions
+            self.uut.OpenstackREST(FakeServiceSessions(self.fake_session))
+
+    def fake_time(self, sleep=1):
+        """Return fake_time_value after incrementing it by 1"""
+        self.fake_time_value += sleep
+        return self.fake_time_value
+
+    def certify_stdout(self, name, ip_address):
+        """Helper for checking stdout contents contains what playbooks expect"""
+        write_calls = self.uut.sys.stdout.write.call_args_list
+        written = None
+        for write_call in write_calls:
+            if len(write_call) and len(write_call[0]) and name in write_call[0][0]:
+                written = write_call[0][0]
+                break
+        self.assertIsNotNone(written)
+        for token in ('---', 'inventory_hostname', 'ansible_ssh_host'):
+            self.assertIn(token, written)
+        for value in (name, ip_address):
+            self.assertIn(value, written)
+        self.assertEqual(written[-1], '\n')
+
+    def leftovers(self):
+        """Return string to help with checking requests == responses"""
+        return ("Disused mock request sequence_numbers in %s: %s"
+                % (self.filename,
+                   [m.sequence_number for m in self.fake_session.resp_mocks]))
+
+
+class TestTimeoutAction(TestDiscoverCreateDestroyBase):
+    """Test fixture for TimeoutAction class"""
+
+    def test_timeout_action(self):
+        """Test TimeoutAction base-class under mocked time.time"""
+
+        # self.uut.TimeoutAction class loaded during setUp()
+        # makes pylint very very mad.
+        # pylint: disable=E1003,E1002,E0213,E1101,R0201,E1102,W0232
+        class TimeoutActionTest(self.uut.TimeoutAction):
+            """docstring"""
+            timeout = 5
+            sleep = 1
+            def am_done(inner_self, one, two=3, three=2):
+                """docstring"""
+                if one == 1 and two == 2 and three == 3:
+                    return one + two + three
+                else:
+                    return None
+
+        inst = TimeoutActionTest(42)
+        self.assertRaises(RuntimeError, inst)
+
+        inst = TimeoutActionTest(1, 2)
+        self.assertRaises(RuntimeError, inst)
+
+        self.fake_time_value = 123456
+        inst = TimeoutActionTest(1, three=3, two=2)
+        self.assertEqual(inst(), 6)
+        self.assertEqual(inst.time_out_at, 123456 + TimeoutActionTest.timeout + 1)
+        expected = 123456 + 1 + 1 + 1
+        self.assertEqual(self.fake_time_value, expected)
+
+
+class TestDiscoverCreate(TestDiscoverCreateDestroyBase):
+    """Test discover function with mocked keystone_session"""
+
+    resp_filename_prefix = '.test_openstack_TestDiscoverCreate.'
+
+    def setUp(self):
+        super(TestDiscoverCreate, self).setUp()
+        self.mock_open = mock_open(read_data='bibble babble')
+        self.patched = patch('%s.open' % self.UUT, self.mock_open, create=True)
+
+    def test_missing(self):
+        """Verify discover fails, but creation works with available floating ip"""
+        with self.patched:
+            self.uut.create('foobar', ['list', 'of', 'ssh', 'keys'])
+        self.certify_stdout('foobar', '5.4.3.2')
+        # Verify all requests were consumed; requests == replies
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+    def test_floating(self):
+        """Verify discover fails, but creation works, including creating floating ip"""
+        with self.patched:
+            self.uut.create('foobar', ['list', 'of', 'ssh', 'keys'])
+        self.certify_stdout('foobar', '192.168.1.2')
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+    def test_partial(self):
+        """Verify partially created VM is removed and re-created"""
+        with self.patched:
+            self.uut.create('foobar', ['list', 'of', 'ssh', 'keys'])
+        self.certify_stdout('foobar', '6.5.4.3')
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+    def test_found(self):
+        """Verify existing VM details are returned with discover call"""
+        with self.patched:
+            self.uut.discover('foobar')
+        self.certify_stdout('foobar', '6.7.8.9')
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+
+class TestDestroy(TestDiscoverCreateDestroyBase):
+    """Test destroy function with mocked keystone_session"""
+
+    resp_filename_prefix = '.test_openstack_TestDestroy.'
+
+    def test_missing(self):
+        """Verify destroy behavior when VM name not found"""
+        self.uut.destroy('does_not_exist')
+        # Verify all requests were consumed; requests == replies
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+    def test_found(self):
+        """Verify destroy behavior when VM name found"""
+        self.uut.destroy('rhel')
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+    def test_other(self):
+        """Verify destroy behavior when other servers deleted/created"""
+        self.uut.destroy('does_not_exist')
+        self.assertEqual(self.fake_session.resp_mocks, [], self.leftovers())
+
+
+if __name__ == '__main__':
+    unittest.main(failfast=True, catchbreak=True, verbosity=2)


### PR DESCRIPTION
Work-in-progress (it's a mess).  Releasing early for review/feedback (yes I know it needs functions).  Incomplete and minimally tested at this point (copy-paste into python CLI).  Only supports kommandir discovery (not creation or removal yet).  Requires ``clouds.yml`` to exist in ``$WORKSPACE`` (as in, you put it there).  Though supporting ``OS_*`` env. vars. can be done as well.  I'm not sure if I want to continue using the REST API (portable, less library version sensitive, very fast) or just shell-out to the ``openstack`` CLI (ease of implementation, but possibly more version sensitive)