### PR TITLE
Experiment: Don't install docker-selinux, it's obsoleted by container-selinux

### DIFF
--- a/group_vars/centos/installed_rpms.yml
+++ b/group_vars/centos/installed_rpms.yml
@@ -9,7 +9,6 @@ installed_rpms:
     - docker
     - docker-latest
     - atomic
-    - docker-selinux
     - procps
     - tar
     - findutils

--- a/group_vars/fedora/installed_rpms.yml
+++ b/group_vars/fedora/installed_rpms.yml
@@ -5,7 +5,6 @@ use_dnf: True
 installed_rpms:
     - docker
     - atomic
-    - docker-selinux
     - procps
     - tar
     - findutils

--- a/group_vars/rhel/installed_rpms.yml
+++ b/group_vars/rhel/installed_rpms.yml
@@ -10,7 +10,6 @@ installed_rpms:
     - docker
     - docker-latest
     - atomic
-    - docker-selinux
     - procps
     - tar
     - lvm2


### PR DESCRIPTION
In some flavors of fedora/rhel/centos, package dependencies and/or
obsolete-fixing is broken such that; if installed, every 'docker run'
command will trigger avc denials + go panics.

Signed-off-by: Chris Evich <cevich@redhat.com>