### PR TITLE
Drop CentOS testing, add Upgrade testing

### DIFF
--- a/group_vars/openstack
+++ b/group_vars/openstack
@@ -28,9 +28,10 @@ adept_openstack:
     # Mapping of image name + version to openstack images
     image_map:
         centos:
-                "7.2": "CentOS-Cloud-7"
+                "7.3": "CentOS-Cloud-7"
+                "7.2": "CentOS-Cloud-7.2"
         centosatomic:
-                "7.2": "CentOS-Atomic-7"
+                "7.3": "CentOS-Atomic-7"
         rhel:
                 "7.2": "rhel-7.2-server-x86_64-released"
                 "7.3": "rhel-7.3-server-x86_64-released"

--- a/vars/peon_defaults.yml
+++ b/vars/peon_defaults.yml
@@ -18,23 +18,6 @@ peon_defaults:
       extra_groups: ["docker"]
 
     # Named defaults
-    centos:
-      volume: "20"
-      version: '7.2'
-      groups:
-        - centos
-        - autotested
-        - peons
-        - updated
-
-    centosatomic:
-      version: '7.2'
-      groups:
-        - centosatomic
-        - atomic_upgrade
-        - autotested
-        - peons
-
     rhel:
       volume: "20"
       groups:
@@ -45,25 +28,6 @@ peon_defaults:
         - updated
 
     rhelatomic:
-      groups:
-        - rhelatomic
-        - subscribed
-        - atomic_upgrade
-        - autotested
-        - peons
-
-    rhel-7.2:
-      volume: "20"
-      version: '7.2'
-      groups:
-        - rhel
-        - subscribed
-        - autotested
-        - peons
-        - updated
-
-    rhelatomic-7.2:
-      version: '7.2'
       groups:
         - rhelatomic
         - subscribed

--- a/vars/peons.yml
+++ b/vars/peons.yml
@@ -31,28 +31,33 @@ peons:
     - name: "rhelatomic"
       defaults: "rhelatomic"
 
-    - name: "centos"
-      defaults: "centos"
+    # Upgrade testing
+    - name: "rhel-upgraded"
+      defaults: "rhel"
+      version: 7.2
 
-    - name: "centosatomic"
-      defaults: "centosatomic"
+    - name: "rhelatomic-upgraded"
+      defaults: "rhelatomic"
+      version: 7.2
 
-    # Docker latest
-    - name: "rhel_latest"
+    # Docker latest (overwrite default extra_groups)
+    - name: "rhel-dockerlatest"
       defaults: "rhel"
       extra_groups: ["docker-latest"]
 
-    - name: "rhelatomic_latest"
+    - name: "rhelatomic-dockerlatest"
       defaults: "rhelatomic"
       userdata: '{{ docker_latest_userdata }}'
       extra_groups: ["docker-latest"]
 
-    - name: "centos_latest"
-      defaults: "centos"
+    # Docker latest upgrade testing
+    - name: "rhel-upgraded-dockerlatest"
+      defaults: "rhel"
+      version: 7.2
       extra_groups: ["docker-latest"]
 
-    - name: "centosatomic_latest"
-      defaults: "centosatomic"
+    - name: "rhelatomic-upgraded-dockerlatest"
+      defaults: "rhelatomic"
+      version: 7.2
       userdata: '{{ docker_latest_userdata }}'
       extra_groups: ["docker-latest"]
-


### PR DESCRIPTION
Also, some peon name prefixes changed for clarity,
(e.g. rhelatomic-latest -> rhelatomic-dockerlatest)

and for consistency with new upgrade-testing:
    e.g. rhel-7.2upgraded-dockerlatest

Signed-off-by: Chris Evich <cevich@redhat.com>