### PR TITLE
Fix version number vs string

### DIFF
--- a/roles/peon/tasks/peons_guuid.yml
+++ b/roles/peon/tasks/peons_guuid.yml
@@ -19,29 +19,30 @@
   set_fact:
     _peon: '{{ _peon | combine({"groups": _groups}) }}'
 
-- block:
+- name: peon version forced to be a string
+  set_fact:
+    _peon: '{{ _peon | combine({"version": _peon.version | string}) }}'
 
-    # Not unique! Seed comes from adept_job + matrix parameters.
-    - name: peon uuid is generated
-      set_fact:
-        _uuid: "{{
-                    _peon.name
-                }}-{{
-                    _peon.version | trim
-                }}-{{
-                    adept_job
-                }}-{{
-                    _peon | to_uuid |
-                    regex_replace('(\\w+-){4}(\\w+)', '\\2')
-                }}"
+- name: peon shorter-uuid is generated
+  set_fact:
+    _uuid: "{{
+                _peon.name
+            }}-{{
+                _peon.version | trim
+            }}-{{
+                adept_job
+            }}-{{
+                _peon | to_uuid |
+                regex_replace('(\\w+-){4}(\\w+)', '\\2')
+            }}"
 
-    - name: peon uuid is also valid dns name
-      set_fact:
-        _uuid: "{{ _uuid | trim | regex_replace('[^-a-zA-Z0-9]', '-') }}"
+- name: peon uuid is also valid dns name
+  set_fact:
+    _uuid: "{{ _uuid | trim | regex_replace('[^-a-zA-Z0-9]', '-') }}"
 
-    - name: peon uuid is set
-      set_fact:
-        _peon: '{{ _peon | combine({"uuid": _uuid}) }}'
+- name: peon uuid is set
+  set_fact:
+    _peon: '{{ _peon | combine({"uuid": _uuid}) }}'
 
 - name: peon is stored in buffer
   set_fact:

--- a/vars/peons.yml
+++ b/vars/peons.yml
@@ -34,11 +34,11 @@ peons:
     # Upgrade testing
     - name: "rhel-upgraded"
       defaults: "rhel"
-      version: 7.2
+      version: "7.2"
 
     - name: "rhelatomic-upgraded"
       defaults: "rhelatomic"
-      version: 7.2
+      version: "7.2"
 
     # Docker latest (overwrite default extra_groups)
     - name: "rhel-dockerlatest"
@@ -53,11 +53,11 @@ peons:
     # Docker latest upgrade testing
     - name: "rhel-dockerlatest-upgraded"
       defaults: "rhel"
-      version: 7.2
+      version: "7.2"
       extra_groups: ["docker-latest"]
 
     - name: "rhelatomic-dockerlatest-upgraded"
       defaults: "rhelatomic"
-      version: 7.2
+      version: "7.2"
       userdata: '{{ docker_latest_userdata }}'
       extra_groups: ["docker-latest"]


### PR DESCRIPTION
This value is used for looking up the image when creating a peon.
However, when used as mapping keys, the object type is important.
This supports simple typos like treating a two-component version
as if it was a floating point number.  Since the image map uses
string version number keys, the floating-point numbers from the peon
definition wouldn't match, resulting in an error.  This commit
both fixes the source of the problem, and adds a conversion
of all peon version values, into strings.

Signed-off-by: Chris Evich <cevich@redhat.com>