### PR TITLE
typo fix: registry.access.redhat.com

### DIFF
--- a/roles/autotested/templates/subtests.ini.j2
+++ b/roles/autotested/templates/subtests.ini.j2
@@ -2,7 +2,7 @@
 
 {% if test_image_fqin is defined %}[docker_cli/create/create_remote_tag]
 config_version = 0.8.6
-remote_image_fqin = {{ "docker.io/fedora:latest" if "Fedora" in ansible_distribution else "registery.access.redhat.com/rhel7/rhel:latest" }}
+remote_image_fqin = {{ "docker.io/fedora:latest" if "Fedora" in ansible_distribution else "registry.access.redhat.com/rhel7/rhel:latest" }}
 run_options_csv ={% endif %}
 
 [docker_cli/pull]
@@ -13,7 +13,7 @@ subsubtests = good,wrong_tag,wrong_registry_addr
 
 {% if test_image_fqin is defined %}[docker_cli/run/run_remote_tag]
 config_version = 0.8.5
-remote_image_fqin = {{ "docker.io/fedora:latest" if "Fedora" in ansible_distribution else "registery.access.redhat.com/rhel7/rhel:latest" }}
+remote_image_fqin = {{ "docker.io/fedora:latest" if "Fedora" in ansible_distribution else "registry.access.redhat.com/rhel7/rhel:latest" }}
 run_options_csv =
 cmd = /bin/true{% endif %}
 


### PR DESCRIPTION
Should fix this ADEPT failure in docker create test:

   Get https://registery.access.redhat.com/v1/_ping: dial tcp: lookup registery.access.redhat.com on 172.16.12.2:53: no such host: expected 0; got 1

Signed-off-by: Ed Santiago <santiago@redhat.com>