### PR TITLE
Specialize run/run_update test for RHEL

### DIFF
--- a/roles/autotested/templates/subtests.ini.j2
+++ b/roles/autotested/templates/subtests.ini.j2
@@ -37,4 +37,8 @@ docker_expected_exit_status = 0
 [docker_cli/run/run_install]
 install_cmd = yum --disablerepo="*" --enablerepo="rhel-7-server-rpms" --assumeyes install iputils
 verify_cmd = ping -c 10 -q registry.access.redhat.com
+
+[docker_cli/run/run_update]
+generate_generic = yes
+cmd = 'yum --disablerepo="*" --enablerepo="rhel-7-server-rpms" --assumeyes update'
 {% endif %}


### PR DESCRIPTION
The upstream configuration (https://github.com/autotest/autotest-docker/pull/707) is generic.  Some repo-masking is needed to test this to pass under RHEL and RHELAH so that extraneous test repositories can't get in the way.  Exact same reason why "run_install" is specialized.