### PR TITLE
Update control file template for autotested role

### DIFF
--- a/roles/autotested/templates/control.ini.j2
+++ b/roles/autotested/templates/control.ini.j2
@@ -1,15 +1,4 @@
-# Autotest-control configuration, not consumed by dockertest or subtests
-# directly.  Though job.resultdir will contain an updated reference copy.
-
 [Control]
-
-# Subtests/sub-subtest names to run (CSV, in order)
-# **instead** of searching the subtests directory.
-# Any also specified by the --args i=<csv> sub-option and
-# are not on this list, will prefix resulting list (also in order)
-
-# e.g. "docker_cli/version"
-include =
 
 # Subtests/sub-subtest names to remove from include (above)
 # in addition to any specified by --args x=<csv> sub-option.
@@ -28,67 +17,8 @@ exclude = example,subexample,pretest_example,intratest_example,
           docker_test_images
 {% endif %}
 
-# Subtests/Sub-subtest to consider for inclusion before
-# consulting include/exclude (above).
-subthings =
-
-# Directory relative to control file, where pre-test modules
-# are located.  These execute in alpha-order before any other
-# modules.
-pretests = pretests
-
-# Directory relative to control file, where sub-test modules
-# are located.  These are the main testing module content,
-# controlled by subthings, include, and exclude (above).
-subtests = subtests
-
-# Directory relative to control file, where intra-test modules
-# are located.  These are executed in alpha-order, in-between
-# each subtest module.
-intratests = intratests
-
-# Directory relative to control file, where post-test modules
-# are located.  These execute in alpha-order, after all subtest
-# modules.
-posttests = posttests
-
 [Bugzilla]
-
-# If non-empty, enable automatic additions to exclude list,
-# by bugzilla status.  Bugzilla server url to connect to
-url = https://bugzilla.redhat.com/xmlrpc.cgi
 
 # Authentication options if required
 username = {{ _private_bugzilla_username | default("") }}
 password = {{ _private_bugzilla_password | default("") }}
-
-# This will automatically be populated
-# with names of subtests/sub-subtests excluded
-# in results reference control.ini.  Though you may add
-# items here but they will have the same effect as if they
-# were added in 'exclude' (above)
-excluded =
-
-# Bugzilla bug field name that encodes the subtest/sub-subtest
-# name to exclude.  The format searched for is '<key_match>:<subthing>'
-# where key_match is defined below.  e.g. 'whiteboard' will look for
-# <key_match>:<subthing> in the 'whiteboard' bug field.
-key_field = status_whiteboard
-
-# Value that must match inside key_field for query (below), this allows
-# differientiation between different jobs/configurations matching
-# their own set of bugs.  It's used along with the key_field (above)
-key_match = docker-autotest
-
-[Query]
-
-# All keys/values defined here will be passed as arguments to
-# Bugzilla.build_query() in addition to 'status' and
-# 'key_match' above.
-
-product = Red Hat Enterprise Linux 7
-component = docker, docker-distribution, docker-registry, atomic,
-            rhel-server-atomic, rhel-server-docker, rhel-tools-docker,
-            rsyslog-docker, sadc-docker, sssd-docker, runc, skopeo,
-            ostree, rpm-ostree
-status = NEW, ASSIGNED, POST, MODIFIED, ON_DEV, VERIFIED


### PR DESCRIPTION
After autotest/autotest-docker #710 it's not necessary to re-specify all
non-default control.ini options.  Only those which should override them
need to be written.

Signed-off-by: Chris Evich <cevich@redhat.com>