### PR TITLE
Don't kill the tool needed to do the work

### DIFF
--- a/files/slave_container.xn
+++ b/files/slave_container.xn
@@ -65,10 +65,9 @@
             /usr/bin/docker rmi --force \
                                 adept_slave:latest;'
 
-# Prune 5-day old(er) files from workspace so it doesn't constantly fill up
+# Prune 1-day old(er) files from workspace so it doesn't constantly fill up
 - command:
     contexts:
         - cleanup
     filepath: /bin/find
-    arguments: "/mnt/workspaces -atime +5 -exec rm -f {} +"
-
+    arguments: "/mnt/workspaces -atime +1 -exec rm -f {} +"

--- a/roles/sync_back/tasks/main.yml
+++ b/roles/sync_back/tasks/main.yml
@@ -49,6 +49,5 @@
   ignore_errors: True  # Don't fail play on missing item
   # No reason to leave these around to soak up diskspace
   with_items:
-    - "adept"
     - "cache"
     - "dockertest"

--- a/roles/sync_back/tasks/main.yml
+++ b/roles/sync_back/tasks/main.yml
@@ -44,6 +44,7 @@
 - name: Giblets in kommandir's workspace are removed during cleanup
   file:
     path: "{{ kommandir_workspace }}/{{ item }}"
+    recurse: true
     state: absent
   when: 'adept_context == "cleanup"'
   ignore_errors: True  # Don't fail play on missing item


### PR DESCRIPTION
At the end of cleanup, some directories in the kommandir's workspace are
removed after sync'ing them back to the starting host.  This partly
prevents rapid consumption of workspace cache on the kommandir VM.
However, it was removing the ``adept`` directory, which is required by
external callers to perform additional cleanup steps.  Don't remove this
directory.

Signed-off-by: Chris Evich <cevich@redhat.com>