### PR TITLE
Fix liverestore peon configuration

### DIFF
--- a/roles/liverestore_enabled/tasks/main.yml
+++ b/roles/liverestore_enabled/tasks/main.yml
@@ -19,11 +19,11 @@
   with_fileglob:
     - "/usr/lib/systemd/system/docker*.service"
 
-- name: The MountFlags=slave option is not present in customized unit files
+- name: The MountFlags=slave option is replaced with KillMode=process in unit files
   replace:
     dest: "{{ item }}"
     regexp: 'MountFlags=slave'
-    replace: ''
+    replace: 'KillMode=process'
   with_fileglob:
     - "/usr/lib/systemd/system/docker*.service"
 

--- a/roles/liverestore_enabled/tasks/main.yml
+++ b/roles/liverestore_enabled/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: docker services are stopped
+- name: docker/docker-latest services are stopped
   service:
     name: "{{ item }}"
     state: stopped
@@ -10,22 +10,45 @@
     - "docker"
     - "docker-latest"
 
-- name: Copy systemd unit files for customization
-  copy:
-    remote_src: True
-    src: "{{ item }}"
-    dest: "/etc/systemd/system/{{ item | basename() }}"
-  when: 'is_enterprise or not item | search("latest")'
-  with_fileglob:
-    - "/usr/lib/systemd/system/docker*.service"
+- name: The docker/docker-latest systemd unit config. drop-directory exists
+  file:
+    path: "/etc/systemd/system/{{ item }}.service.d"
+    state: directory
+  when: 'is_enterprise or item != "docker-latest"'
+  with_items:
+    - "docker"
+    - "docker-latest"
 
-- name: The MountFlags=slave option is replaced with KillMode=process in unit files
-  replace:
-    dest: "{{ item }}"
-    regexp: 'MountFlags=slave'
-    replace: 'KillMode=process'
-  with_fileglob:
-    - "/usr/lib/systemd/system/docker*.service"
+- name: The docker/docker-latest config. drop-file is marked ansible-managed
+  blockinfile:
+    path: "/etc/systemd/system/{{ item }}.service.d/liverestore.conf"
+    create: True
+  when: 'is_enterprise or item != "docker-latest"'
+  with_items:
+    - "docker"
+    - "docker-latest"
+
+- name: docker/docker-latest config. drop-file's MountFlags option is cleared
+  inifile:
+    path: "/etc/systemd/system/{{ item }}.service.d/liverestore.conf"
+    group: "Service"
+    option: "MountFlags"
+    value: ""
+  when: 'is_enterprise or item != "docker-latest"'
+  with_items:
+    - "docker"
+    - "docker-latest"
+
+- name: docker/docker-latest config. drop-file's KillMode option is set
+  inifile:
+    path: "/etc/systemd/system/{{ item }}.service.d/liverestore.conf"
+    group: "Service"
+    option: "KillMode"
+    value: "process"
+  when: 'is_enterprise or item != "docker-latest"'
+  with_items:
+    - "docker"
+    - "docker-latest"
 
 - name: Systemd is reloaded
   command: systemctl daemon-reload


### PR DESCRIPTION
Based on RHEL ``7.4`` testing, a missing option in the docker/latest unit
files was found.  With this commit, the only special/additional setup
steps for enabling liverestore are:

* Starting with daemons stopped, ``container-storage-setup``
  hasn't run yet.
* Rely on runc package to have tweaked kernel params (all platforms)
* Copy ``/usr/lib/systemd/system/docker*.service`` into
  ``/etc/systemd/system/``
* In the copies, replace ``MountFlags=slave`` with ``KillMode=process``
* Start/enable docker or docker-latest services (implied
  ``container-storage-setup``)

Signed-off-by: Chris Evich <cevich@redhat.com>