### PR TITLE
Fix timeout gathering exekutir facts

### DIFF
--- a/exekutir/ansible.cfg
+++ b/exekutir/ansible.cfg
@@ -47,7 +47,7 @@ gathering = smart
 # You can combine them using comma (ex: network,virtual)
 # You can negate them using ! (ex: !hardware,!facter,!ohai)
 # A minimal set of facts is always gathered.
-gather_subset = network
+gather_subset = facter
 
 # additional paths to search for roles in, colon separated
 # N/B: This depends on how ansible is called

--- a/exekutir/cleanup_after_job.yml
+++ b/exekutir/cleanup_after_job.yml
@@ -8,7 +8,6 @@
     - meta: clear_host_errors
 
 - hosts: kommandir:!nocloud
-  gather_subset: 'network'
   vars_files:
       - exekutir_vars.yml
   roles:
@@ -19,7 +18,6 @@
       meta: refresh_inventory
 
 - hosts: exekutir
-  gather_subset: 'network'
   vars_files:
       - exekutir_vars.yml
   roles:

--- a/exekutir/roles/kommandir_up/tasks/main.yml
+++ b/exekutir/roles/kommandir_up/tasks/main.yml
@@ -44,4 +44,4 @@
 
 - name: Kommandir's facts are gathered
   setup:
-    gather_subset: 'network'
+    gather_subset: 'facter'

--- a/exekutir/run_before_job.yml
+++ b/exekutir/run_before_job.yml
@@ -4,7 +4,6 @@
 - include: setup_before_job.yml
 
 - hosts: kommandir
-  gather_subset: 'network'
   vars_files:  # Still running from exekutir
       - exekutir_vars.yml
   tasks:

--- a/exekutir/setup_after_job.yml
+++ b/exekutir/setup_after_job.yml
@@ -2,14 +2,12 @@
 
 # Some Exekutir variable values are referenced by kommandir
 - hosts: all
-  gather_subset: 'network'
   vars_files:
       - exekutir_vars.yml
   roles:
     - common
 
 - hosts: kommandir:!nocloud
-  gather_subset: 'network'
   vars_files:
       - exekutir_vars.yml
   roles:

--- a/exekutir/setup_before_job.yml
+++ b/exekutir/setup_before_job.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: exekutir
-  gather_subset: 'network'
   vars_files:
       - exekutir_vars.yml
   pre_tasks:
@@ -38,7 +37,6 @@
 
 # All kommandir's
 - hosts: kommandir
-  gather_subset: 'network'
   vars_files:  # Still running from exekutir
       - exekutir_vars.yml
   roles:

--- a/kommandir/ansible.cfg
+++ b/kommandir/ansible.cfg
@@ -47,7 +47,7 @@ gathering = smart
 # You can combine them using comma (ex: network,virtual)
 # You can negate them using ! (ex: !hardware,!facter,!ohai)
 # A minimal set of facts is always gathered.
-gather_subset = network
+gather_subset = facter
 
 # additional paths to search for roles in, colon separated
 # N/B: This depends on how ansible is called

--- a/kommandir/cleanup.yml
+++ b/kommandir/cleanup.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - name: Gather kommandir facs exclusive of other inventory hosts
       setup:
-        gather_subset: 'network'
+        gather_subset: 'facter'
   roles:
     # Needed to group/add all peons
     - common
@@ -47,6 +47,6 @@
   pre_tasks:
     - name: Gather kommandir facs exclusive of other inventory hosts
       setup:
-        gather_subset: 'network'
+        gather_subset: 'facter'
   roles:
     - workspace_cleanup

--- a/kommandir/kommandir_before_peons.yml
+++ b/kommandir/kommandir_before_peons.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - name: Gather kommandir facs exclusive of other inventory hosts
       setup:
-        gather_subset: 'network'
+        gather_subset: 'facter'
   roles:
     - common
     - role: ansible_versioned

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -21,7 +21,7 @@
       with_items: "{{ result.results }}"
       when: adept_debug
     - setup:
-        gather_subset: []
+        gather_subset: 'facter'
   roles: # N/B: failed_peon_junit role applied via role dependencies
     - common
     - peon_common

--- a/kommandir/setup.yml
+++ b/kommandir/setup.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - name: Gather kommandir facs exclusive of other inventory hosts
       setup:
-        gather_subset: 'network'
+        gather_subset: 'facter'
   roles:
     - common
     - ansible_versioned


### PR DESCRIPTION
Limit all fact gathering to just the facter minimal fact collection.
This resolves problems with timeouts gathering facts on "localhost"
where the vast majority are irrelivent.

Signed-off-by: Chris Evich <cevich@redhat.com>