### PR TITLE
Fix default glob used when cleaning workspace

### DIFF
--- a/exekutir/roles/workspace_cleanup/tasks/main.yml
+++ b/exekutir/roles/workspace_cleanup/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: The result variable lists 'workspace/*' when cleanup_globs is empty
   set_fact:
     result:
-        - '{{ workspace }}/*'
+        - '*'
   when: cleanup_globs | default() in empty
 
 - name: The result variable buffers the cleanup_globs variable


### PR DESCRIPTION
The find module is already restricted to workspace, specifying it again
in the pattern (stored in "result") causes no files to be matched.

Signed-off-by: Chris Evich <cevich@redhat.com>