### PR TITLE
Fix a few non-essential missing deps on the Kommandir

### DIFF
--- a/exekutir/inventory/host_vars/kommandir.yml
+++ b/exekutir/inventory/host_vars/kommandir.yml
@@ -25,6 +25,9 @@ install_rpms:
     - PyYAML
     - python-virtualenv
     - gcc
+    - redhat-rpm-config
+    - openssl-devel
+    - libffi-devel
     - ansible
 
 git_cache_args:


### PR DESCRIPTION
These make installing Ansible via pip easier, should locking down
it's version per-job be needed in the future.

Signed-off-by: Chris Evich <cevich@redhat.com>