### PR TITLE
Support recycle pre-existing & kill nocloud-peons

### DIFF
--- a/kommandir/cleanup.yml
+++ b/kommandir/cleanup.yml
@@ -20,15 +20,18 @@
   vars_files:
       - kommandir_vars.yml
   roles:
+    - role: peon_up
+      reboot_context: "Cleanup"
+      when: inventory_hostname != "kommandir"
+
     - role: unsubscribed
       when: cleanup and
             inventory_hostname != "kommandir" and
-            "subscribed" in group_names and
-            "nocloud" not in group_names
+            "subscribed" in group_names
   post_tasks:
     - meta: clear_host_errors
 
-- hosts: peons:!nocloud
+- hosts: peons
   # Can't assume hosts are reachable
   gather_facts: False
   vars_files:

--- a/kommandir/inventory/group_vars/recycled.yml
+++ b/kommandir/inventory/group_vars/recycled.yml
@@ -1,0 +1,11 @@
+---
+
+# Members of this group are assumed to already exist with details in their host_vars file.
+
+cloud_environment:
+
+cloud_asserts:
+
+cloud_provisioning_command:
+
+cloud_destruction_command:

--- a/kommandir/inventory/nocloud
+++ b/kommandir/inventory/nocloud
@@ -1,2 +1,0 @@
-[nocloud]
-kommandir

--- a/kommandir/peon_creation.yml
+++ b/kommandir/peon_creation.yml
@@ -2,7 +2,7 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
-- hosts: peons:!nocloud
+- hosts: peons
   # Inventory is incomplete
   gather_facts: False
   vars_files:
@@ -10,6 +10,7 @@
   roles:
     - common
     - role: peon_created
-      when: ansible_host | default() not in empty
+      when: ansible_host | default() not in empty and
+            "recycled" not in group_names
     - role: peon_up
       reboot_context: "creation"

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -2,7 +2,7 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
-- hosts: peons:!nocloud
+- hosts: peons:!recycled
   gather_facts: False  # Need peon_pre_raw_cmds run first
   # Outside of debug-mode, run all peons as fast as possible
   strategy: "{{ 'linear' if adept_debug else 'free' }}"
@@ -96,6 +96,14 @@
       when: not hostvars[inventory_hostname].stone_touched and
             sysconfig_dss_lines | default([]) != []
 
+
+- hosts: peons
+  gather_facts: False  # Need peon_pre_raw_cmds run first
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles:
     - selinux_enforcing
 
     - services

--- a/kommandir/roles/peon_up/defaults/main.yml
+++ b/kommandir/roles/peon_up/defaults/main.yml
@@ -5,3 +5,6 @@
 wait_for_timeout: 13
 
 test_command_template: '{{ playbook_dir }}/roles/peon_up/templates/test_command.sh.j2'
+
+# When empty, do not include application of failed_peon_junit role
+reboot_context:


### PR DESCRIPTION
Since setting up a peon takes a non-trivial amount of time, it makes
sense to support recycling.  When a peon is a member of the ``recycled``
group, then it will not be provisioned or have any low-level setup
performed.

It's assumed from the start, that the peon's ``kommandir_workspace/inventory/host_vars``
file is correct/current. Which probably means copying it there
via a ``extra_exekutir_setup`` or ``extra_kommandir_setup`` command
(since the workspace is wiped out during ``exekutir_workspace_setup``).

Also nuke all references to ``nocloud`` peons, since the destinction
doesn't make much sense and wasn't ever used/applied correctly.

Signed-off-by: Chris Evich <cevich@redhat.com>