### PR TITLE
Fix not using global lock on kommandir

### DIFF
--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -982,7 +982,7 @@ def parse_args(argv, operation='help'):
                             help=('Path to filename containing cloud-config userdata'
                                   ' YAML to use instead of default (Optional).'))
 
-        parser.add_argument('--lockdir', '-l', default='', type=str,
+        parser.add_argument('--lockdir', '-l', default=None, type=str,
                             help=('Absolute path to directory where global lock file'
                                   ' should be created/used.'))
 
@@ -1242,7 +1242,7 @@ if __name__ == '__main__':  # pylint: disable=C0103
     Flock.def_prefix = WORKSPACE_LOCKFILE_PREFIX
 
     # initialize global lock singleton
-    if 'lockdir' in _dargs:
+    if bool(_dargs.get('lockldir')):
         OpenstackLock(os.path.join(_dargs['lockdir'],
                                    '%s.lock' % WORKSPACE_LOCKFILE_PREFIX))
     else:

--- a/kommandir/inventory/group_vars/openstack.yml
+++ b/kommandir/inventory/group_vars/openstack.yml
@@ -40,6 +40,7 @@ cloud_provisioning_command:
     command: >
         bin/openstack_exclusive_create.py \
             {{ "--verbose" if adept_debug == True else "" }} \
+            {{ "--lockdir=" ~ hostvars.kommandir.global_lockdir if hostvars.kommandir.global_lockdir|default() not in empty else ""}} \
             --image {{ peon_image }} \
             --flavor {{ peon_flavor }} \
             {{ "--private" if public_peons is undefined or public_peons != True else "" }} \


### PR DESCRIPTION
On an active Kommandir, it's possible for jobs to contend with eachother
over allocating floating IP addresses.  Partially address this by
using a system-wide lock directory.  This was previously setup in a
prior commit, but not realized via kommandir/inventory/group_vars/openstack.yml

This does not address the issue where multiple kommandirs all contend
for public IPs, however solving that is non-trivial and out-of-scope for
this small fix.

Also include a fix to adept_openstack.py that results in CWD being
used as the lock dir because of default '' (empty string) parameter value.

Signed-off-by: Chris Evich <cevich@redhat.com>