### PR TITLE
Simplify kommandir_vars.yml init. and comments

### DIFF
--- a/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
@@ -7,18 +7,19 @@
 job_docs_template_src: README
 job_docs_template_dest: README
 
-# This list of keys to be filtered out of exekutir_vars.yml when
-# iitializing kommandir_vars.yml
-kommandir_vars_exclude_keys: >
-  {{ lookup("file", workspace ~ "/roles/installed/defaults/main.yml")
-         | from_yaml | to_json | from_json | list +
-     lookup("file", workspace ~ "/roles/compatible_ansible/defaults/main.yml")
-         | from_yaml | to_json | from_json | list +
-     ['extra_kommandir_setup', 'extra_exekutir_setup', 'job_path', 'kommandir_groups'] +
-     ['stonith', 'kommandir_name_prefix', 'global_lockdir'] }}
+# This list of keys to be filtered out of kommandir_vars.yml if present
+kommandir_vars_exclude_keys:
+  - 'extra_kommandir_setup'
+  - 'extra_exekutir_setup'
+  - 'job_path'
+  - 'kommandir_groups'
+  - 'stonith'
+  - 'kommandir_name_prefix'
+  - 'global_lockdir'
 
 # This list of keys will be overriden in kommandir_vars.yml basedon
-# on the current exekutir values if defined
+# on the current exekutir values if defined (except global_lockdir
+# which is always overriden)
 kommandir_vars_copy_keys:
   - "cleanup_globs"
   - "uuid"

--- a/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
@@ -118,11 +118,6 @@
     mode: "0444"
     state: "file"
 
-# N/B: Functioning of this section is critical
-#      e.g. if install_rpms is overriden by exekutir_vars.yml it will
-#           clobber that same variable for EVERY peon, when kommandir's
-#           job.xn runs, and playbooks haul in kommandir_vars.yml
-
 - name: Kommandir's kommandir_vars.yml exists as a YAML dictionary
   lineinfile:
     dest: "{{ kommandir_workspace }}/kommandir_vars.yml"

--- a/kommandir/inventory/group_vars/fedora/pre_raw_cmds.yml
+++ b/kommandir/inventory/group_vars/fedora/pre_raw_cmds.yml
@@ -1,4 +1,0 @@
----
-
-pre_raw_cmds:
-    - dnf install -y python python-simplejson python2 python2-dnf libselinux-python


### PR DESCRIPTION
Rather than using a complicated list and filtering exekutir_vars.yml
to setup kommandir_vars.yml, just use a simple list of
excludes/includes.  Also update related comments.

Signed-off-by: Chris Evich <cevich@redhat.com>