### PR TITLE
Fix not skipping peon_up after reboot

### DIFF
--- a/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
@@ -21,6 +21,7 @@ kommandir_vars_exclude_keys:
 # on the current exekutir values if defined (except global_lockdir
 # which is always overriden)
 kommandir_vars_copy_keys:
+  - "public_peons"
   - "cleanup_globs"
   - "uuid"
   - "job_name"

--- a/exekutir/roles/workspace_cleanup/tasks/main.yml
+++ b/exekutir/roles/workspace_cleanup/tasks/main.yml
@@ -40,13 +40,13 @@
   - name: Items that would have been removed are listed
     debug:
       var: "result"
-    when: adept_debug
+    when: adept_debug or 'nocloud' in hostvars.kommandir.group_names
 
   - name: Unnecessary items removed from workspace
     file:
       path: "{{ item }}"
       state: absent
-    when: not adept_debug
+    when: not adept_debug and 'nocloud' not in hostvars.kommandir.group_names
     with_items: '{{ result }}'
 
   when: cleanup_globs | default() not in empty

--- a/jobs/basic/templates/control.ini.j2
+++ b/jobs/basic/templates/control.ini.j2
@@ -14,7 +14,7 @@ exclude = example,subexample,pretest_example,intratest_example,
           {# We never test the RHEL base-image on Fedora #}
           redhat/rhel_push_plugin,
           redhat/packaging,
-          puller
+          docker_test_images/puller
 {% endif %}
 
 # Subtests/Sub-subtest to consider for inclusion before

--- a/kommandir/cleanup.yml
+++ b/kommandir/cleanup.yml
@@ -15,32 +15,18 @@
     # Needed to group/add all peons
     - common
 
-- hosts: all  # Include kommandir, so if all peons fail, clear_host_errors still works
-  gather_facts: False
-  vars_files:
-      - kommandir_vars.yml
-  roles:
-    - role: peon_up
-      reboot_context: "Cleanup"
-      when: inventory_hostname != "kommandir"
-
-    - role: unsubscribed
-      when: cleanup and
-            inventory_hostname != "kommandir" and
-            "subscribed" in group_names
-  post_tasks:
-    - meta: clear_host_errors
-
 - hosts: peons
-  # Can't assume hosts are reachable
   gather_facts: False
   vars_files:
       - kommandir_vars.yml
   roles:
     - common
     - peon_common
+    - role: unsubscribed
+      when: cleanup and
+            "subscribed" in group_names
     - role: peon_destroyed
-      when: cleanup | default(True)
+      when: 'cleanup | default(True) and inventory_hostname != "kommandir"'
 
 - hosts: kommandir
   # Can't assume all hosts are reachable

--- a/kommandir/roles/rebooted/defaults/main.yml
+++ b/kommandir/roles/rebooted/defaults/main.yml
@@ -8,3 +8,16 @@ shutdown_timeout: 30
 
 # Maximum time to wait for system to become available again (in seconds)
 bootup_timeout: 300
+
+# Timeout in (integer) seconds to wait for timeouts and retries when
+# confirming host is accessable.  The default (13) comes from two DNS
+# timeouts + one second
+wait_for_timeout: 13
+
+# The template to use which contains command that confirms host accessability
+test_command_template: '{{ playbook_dir }}/roles/peon_up/templates/test_command.sh.j2'
+
+# When there are multiple reboots in a play, this sets the message which
+# helps destinguish which one failed, when the failed_peon_junit
+# role-dependency is applied.
+reboot_context:

--- a/kommandir/roles/rebooted/tasks/main.yml
+++ b/kommandir/roles/rebooted/tasks/main.yml
@@ -31,9 +31,9 @@
 
   when: needs_reboot == True
 
+- name: Peon is accessable after reboot
+  include: "{{ playbook_dir }}/roles/peon_up/tasks/main.yml"
+
 - name: needs_reboot flag is set false
   set_fact:
     needs_reboot: False
-
-- name: Peon is accessable after reboot
-  include: "{{ playbook_dir }}/roles/peon_up/tasks/main.yml"

--- a/kommandir/roles/unsubscribed/tasks/main.yml
+++ b/kommandir/roles/unsubscribed/tasks/main.yml
@@ -4,10 +4,16 @@
     that:
         - '"subscribed" in group_names'
 
-- name: System is  unsubscribed
-  shell: subscription-manager unregister | true
-  register: result
-  ignore_errors: True
+- block:
+
+    - name: System is  unsubscribed
+      shell: subscription-manager unregister | true
+      register: result
+      ignore_errors: True
+
+  always:
+
+    - meta: clear_host_errors
 
 - name: Result is displayed when adept_debug
   debug:


### PR DESCRIPTION
The peon_up role is included after rebooting.  However, frequently the
rebooted role is only applied ``when needs_reboot == True``.  Since that
conditional is applied to all tasks, and the rebooted role sets it false
before including peon_up, no peon_up checks will run.  Fix this by
changing the order of setting needs_reboot in the reboot role.

Also include a small fix to avoid cleaning up the workspace when not
running with a cloud-based (shared) kommandir.

Signed-off-by: Chris Evich <cevich@redhat.com>