### PR TITLE
Enable setting up peons using 'free' strategy

### DIFF
--- a/exekutir/ansible.cfg
+++ b/exekutir/ansible.cfg
@@ -47,7 +47,7 @@ gathering = smart
 # You can combine them using comma (ex: network,virtual)
 # You can negate them using ! (ex: !hardware,!facter,!ohai)
 # A minimal set of facts is always gathered.
-gather_subset = facter
+gather_subset = network
 
 # additional paths to search for roles in, colon separated
 # N/B: This depends on how ansible is called

--- a/kommandir/ansible.cfg
+++ b/kommandir/ansible.cfg
@@ -47,7 +47,7 @@ gathering = smart
 # You can combine them using comma (ex: network,virtual)
 # You can negate them using ! (ex: !hardware,!facter,!ohai)
 # A minimal set of facts is always gathered.
-gather_subset = facter
+gather_subset = network
 
 # additional paths to search for roles in, colon separated
 # N/B: This depends on how ansible is called

--- a/kommandir/peon_creation.yml
+++ b/kommandir/peon_creation.yml
@@ -14,3 +14,15 @@
             "recycled" not in group_names
     - role: peon_up
       reboot_context: "creation"
+  post_tasks:
+    - name: Some hosts may need ansible-dependencies installed before anything else happens.
+      raw: "{{ item }}"  # raw commands don't require python
+      args:
+        executable: "/bin/bash"
+      register: result
+      with_items: '{{ peon_pre_raw_cmds | default([]) }}'
+    - name: Peon's peon_pre_raw_cmds results are displayed
+      debug:
+          var: "item.stdout_lines"
+      with_items: "{{ result.results }}"
+      when: adept_debug

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -2,27 +2,10 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
-- hosts: peons:!recycled
-  gather_facts: False  # Need peon_pre_raw_cmds run first
-  # Outside of debug-mode, run all peons as fast as possible
-  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+- hosts: peons
   vars_files:
       - kommandir_vars.yml
-  pre_tasks:
-    - name: Some hosts may need python2 installed before anything else happens.
-      raw: "{{ item }}"  # raw commands don't require python
-      args:
-        executable: "/bin/bash"
-      register: result
-      with_items: '{{ peon_pre_raw_cmds | default([]) }}'
-    - name: Peon's peon_pre_raw_cmds results are displayed
-      debug:
-          var: "item.stdout_lines"
-      with_items: "{{ result.results }}"
-      when: adept_debug
-    - setup:
-        gather_subset: 'facter'
-  roles: # N/B: failed_peon_junit role applied via role dependencies
+  roles:
     - common
     - peon_common
 
@@ -31,7 +14,8 @@
       touch_touchstone: False
 
     - role: rendered
-      when: rendered_templates | default() not in empty
+      when: rendered_templates | default() not in empty and
+            not hostvars[inventory_hostname].stone_touched
 
     - role: subscribed
       when: not hostvars[inventory_hostname].stone_touched and
@@ -40,9 +24,30 @@
             rhsm.username | default() not in empty and
             rhsm.password | default() not in empty
 
+    - role: yumrepos
+      when: disable_all_rh_repos | default(False) in [True,False] or
+            enable_rh_repos | default() not in empty or
+            yum_repos | default() not in empty
+
+# Assume recycled peons have already completed low-level
+# setup/configuration
+- hosts: peons:!recycled
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles: # N/B: failed_peon_junit role applied via role dependencies
     - role: rawhide
       when: not hostvars[inventory_hostname].stone_touched and
             'fedora' in group_names and 'rawhide' in group_names
+
+    - role: atomic_rebase
+      when: is_atomic and
+            ostree_remote | default() not in empty and
+            ostree_remote.name | default() not in empty and
+            ostree_remote.url | default() not in empty and
+            ostree_remote.spec | default() not in empty and
+            not hostvars[inventory_hostname].stone_touched
 
     - role: partitioned
       when: not hostvars[inventory_hostname].stone_touched and
@@ -54,28 +59,26 @@
       reboot_context: "beginning"
       when: needs_reboot == True
 
-    - role: yumrepos
-      when: disable_all_rh_repos | default(False) in [True,False] or
-            enable_rh_repos | default() not in empty or
-            yum_repos | default() not in empty
+
+- hosts: peons
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles: # N/B: failed_peon_junit role applied via role dependencies
 
     - role: lvm
-      when: lvg_ops | default() not in empty or
-            lvol_ops | default() not in empty
+      when: not hostvars[inventory_hostname].stone_touched and
+            (lvg_ops | default() not in empty or
+             lvol_ops | default() not in empty)
 
     - role: swap_enabled
-      when: swap_device | default() not in empty
+      when: not hostvars[inventory_hostname].stone_touched and
+            swap_device | default() not in empty
 
     - role: installed
       when: not is_atomic and
             install_rpms | default() not in empty
-
-    - role: atomic_rebase
-      when: is_atomic and
-            ostree_remote | default() not in empty and
-            ostree_remote.name | default() not in empty and
-            ostree_remote.url | default() not in empty and
-            ostree_remote.spec | default() not in empty
 
     - role: atomic_upgrade
       when: is_atomic and
@@ -86,6 +89,18 @@
       reboot_context: "middle"
       when: needs_reboot == True
 
+    # End of low-level one-time-only setup
+    - role: touchstone
+      touch_touchstone: True
+
+
+- hosts: docker:docker-latest:&peons
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles: # N/B: failed_peon_junit role applied via role dependencies
+
     - role: sysconfig_docker
       when: "ansible_distribution != 'Fedora'"
 
@@ -93,12 +108,10 @@
       when: '"liverestore" in group_names'
 
     - role: docker-storage-setup
-      when: not hostvars[inventory_hostname].stone_touched and
-            sysconfig_dss_lines | default([]) != []
+      when: sysconfig_dss_lines | default([]) != []
 
 
 - hosts: peons
-  gather_facts: False  # Need peon_pre_raw_cmds run first
   # Outside of debug-mode, run all peons as fast as possible
   strategy: "{{ 'linear' if adept_debug else 'free' }}"
   vars_files:
@@ -106,14 +119,24 @@
   roles:
     - selinux_enforcing
 
+    # Starting/Restarting docker may run d-s-s
     - services
 
     - role: rebooted
       reboot_context: "end"
       when: needs_reboot == True
 
+
+- hosts: peons:autotested
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles:
+
     - role: autotested
       when: '"autotested" in group_names and docker_autotest is defined'
 
     - role: touchstone
+      touchstone_filepath: "/var/lib/autotested_touchstone"
       touch_touchstone: True

--- a/kommandir/run.yml
+++ b/kommandir/run.yml
@@ -9,6 +9,6 @@
     - common
     - peon_common
     - role: touchstone
-      touch_touchstone: False
+      touchstone_filepath: "/var/lib/autotested_touchstone"
     - role: autotested
       when: stone_touched


### PR DESCRIPTION
In ansible 2.3.1, an error message is emitted if the free strategy is used and the ``add_host`` module appears anywhere in a play.

Signed-off-by: Chris Evich <cevich@redhat.com>