### PR TITLE
Fix use of namespace for fedora_test_image

### DIFF
--- a/kommandir/inventory/group_vars/fedoratomic/autotested.yml
+++ b/kommandir/inventory/group_vars/fedoratomic/autotested.yml
@@ -8,7 +8,7 @@ docker_autotest_templates:
 
 docker_autotest:
     test_image:
-        host: "localhost"
+        host: ""
         user: ""
         name: "fedora_test_image"
         tag: "latest"

--- a/kommandir/roles/autotested/templates/subtests.ini.j2
+++ b/kommandir/roles/autotested/templates/subtests.ini.j2
@@ -47,7 +47,7 @@ cmd = 'yum --disablerepo="*" --enablerepo="rhel-7-server-rpms" --assumeyes updat
 subsubtests = builder,puller
 extra_fqins_csv =
 # Make sure the default test image gets built
-build_name = localhost/fedora_test_image:latest
+build_name = fedora_test_image:latest
 # This only works with http-based URLs on Atomic (not git)
 build_dockerfile = https://github.com/autotest/autotest-docker/raw/master/fedora_test_image.tar.gz
 build_opts_csv = --pull,--force-rm


### PR DESCRIPTION
If it's there, then docker feels compelled to try and contact the
localhost registry (which doesn't exist). Instead, if the
default test image was deleted, we want tests to fail as early as
possible.

Also updated documentation. This change needs to be paired with
a similar change being made in Docker Autotest

Signed-off-by: Chris Evich <cevich@redhat.com>