### PR TITLE
Support passthrough of --args to Docker Autotest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ script:
     - cd docs && SPHINXOPTS="-W" make html
     - cd ..
     - unit2 -vfc
+    - ./test_exekutir_xn.sh
     # Check for some typos / git commit problems (except in this file)
     - for i in $TYPOS; do echo; echo "$i"; git log -p $TRAVIS_COMMIT_RANGE $(ls -1 | grep -v .travis.yml) | grep -a -2 "$i"; test "$?" == "1" || exit 1; done
-    - ./test_exekutir_xn.sh

--- a/docs/source/variables.inc.rst
+++ b/docs/source/variables.inc.rst
@@ -220,6 +220,14 @@ For example, if a variable is specific to a...
     Otherwise, when ``False``, unrestricted access is optional, except by
     the *kommandir*.
 
+``pull_request_description``
+    String, defaults to undefined
+    *Exekutir's* value overrides *kommandi'r*.
+    When set to a string, this is assumed to be the description text contained
+    in the originating pull-request.  Jobs may make use of this however they like.
+    Specifically, the ``autotested`` role will attempt to convert this into
+    a parameter to autotest's ``--args`` option.
+
 .. _stonith:
 
 ``stonith``

--- a/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/defaults/main.yml
@@ -21,7 +21,7 @@ kommandir_vars_exclude_keys:
   - 'cloud_provisioning_command'
   - 'cloud_destruction_command'
 
-# This list of keys will be overriden in kommandir_vars.yml basedon
+# This list of keys will be overriden in kommandir_vars.yml based on
 # on the current exekutir values if defined (except global_lockdir
 # which is always overriden)
 kommandir_vars_copy_keys:
@@ -29,7 +29,6 @@ kommandir_vars_copy_keys:
   - "cleanup_globs"
   - "uuid"
   - "job_name"
-  - "adept_debug"
-  - "cleanup"
   - "no_log_synchronize"
   - "adept_debug"
+  - "pull_request_description"

--- a/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
@@ -118,44 +118,49 @@
     mode: "0444"
     state: "file"
 
+# Variables file parsing (below) validates they contain YAML dictionaries
+# and prevents future parsing-problems by re-writing the parsed YAML
+
 - name: Kommandir's kommandir_vars.yml exists as a YAML dictionary
   lineinfile:
     dest: "{{ kommandir_workspace }}/kommandir_vars.yml"
     line: 'uuid: will_be_replaced'
     create: True
 
-- name: Kommandir's kommandir_vars.yml excludes certain restricted values
-  lineinfile:
-    path: "{{ kommandir_workspace }}/kommandir_vars.yml"
-    regexp: '^{{ item }}:.*'
-    state: absent
-  with_items: "{{ kommandir_vars_exclude_keys }}"
-
-- name: Exekutir's exekutir_vars.yml is buffered
+- name: Empty dictionary buffer is created
   set_fact:
-    result: '{{ lookup("file", workspace ~ "/exekutir_vars.yml")
-                | from_yaml | to_json | from_json }}'
+    result: {}
 
-- name: Kommandir's kommandir_vars.yml file hard-codes some values from exekutir_vars.yml
-  lineinfile:
-    dest: "{{ kommandir_workspace }}/kommandir_vars.yml"
-    regexp: '^{{ item }}:.*'
-    line: '{{ item }}: {{ result[item] | default(hostvars.exekutir[item]) }}'
-  when: item in result or item in hostvars.exekutir
-  with_items: "{{ kommandir_vars_copy_keys }}"
+- name: kommandir_vars.yml is buffered to exclude kommandir_vars_exclude_keys
+  set_fact:
+    result: "{{ result | combine( {item.key: item.value} ) }}"
+  when: item.key not in kommandir_vars_exclude_keys
+  with_dict: '{{ lookup("file", kommandir_workspace ~ "/kommandir_vars.yml") | from_yaml | to_json | from_json }}'
 
-- name: Remote kommandir's kommandir_vars.yml file hard-codes the global_lockdir location
-  lineinfile:
-    dest: "{{ kommandir_workspace }}/kommandir_vars.yml"
-    regexp: '^global_lockdir.*'
-    line: 'global_lockdir: "/var/lock/adept"'
+- name: kommandir_vars.yml file hard-codes kommandir_vars_copy_keys values from exekutir_vars.yml
+  set_fact:
+    result: "{{ result | combine( {item.key: item.value} ) }}"
+  when: item.key in kommandir_vars_copy_keys
+  with_dict: '{{ lookup("file", workspace ~ "/exekutir_vars.yml") | from_yaml | to_json | from_json }}'
+
+- name: kommandir_vars.yml file hard-codes the global_lockdir location
+  set_fact:
+    result: "{{ result | combine( {'global_lockdir': '/var/lock/adept'} ) }}"
   when: '"nocloud" not in kommandir_groups'
 
-- name: Kommandir's kommandir_vars.yml file is marked as ansible managed
-  lineinfile:
-    dest: "{{ kommandir_workspace }}/kommandir_vars.yml"
-    insertbefore: BOF  # Last defined key wins
-    line: "##### ANSIBLE MANAGED FILE ({{ role_path }})"
+- name: On-disk kommandir_vars.yml file is wiped out prior to replacement
+  file:
+    path: "{{ kommandir_workspace }}/kommandir_vars.yml"
+    state: absent
+
+- name: kommandir_vars.yml file is written out from buffer
+  blockinfile:
+    path: "{{ kommandir_workspace }}/kommandir_vars.yml"
+    create: True
+    follow: True
+    marker: "##### {mark} ANSIBLE MANAGED FILE ({{ role_path }})"
+    block: |
+      {{ result | to_nice_yaml(indent=4) }}
 
 - name: If Exekutir's workspace has a cache directory, assume it's pre-populated for use
   file:

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -58,14 +58,6 @@
       reboot_context: "beginning"
       when: needs_reboot == True
 
-
-- hosts: peons
-  # Outside of debug-mode, run all peons as fast as possible
-  strategy: "{{ 'linear' if adept_debug | default(False) else 'free' }}"
-  vars_files:
-      - kommandir_vars.yml
-  roles: # N/B: failed_peon_junit role applied via role dependencies
-
     - role: lvm
       when: not hostvars[inventory_hostname].stone_touched and
             (lvg_ops | default() not in empty or
@@ -74,6 +66,14 @@
     - role: swap_enabled
       when: not hostvars[inventory_hostname].stone_touched and
             swap_device | default() not in empty
+
+
+- hosts: peons
+  # Outside of debug-mode, run all peons as fast as possible
+  strategy: "{{ 'linear' if adept_debug | default(False) else 'free' }}"
+  vars_files:
+      - kommandir_vars.yml
+  roles: # N/B: failed_peon_junit role applied via role dependencies
 
     - role: installed
       when: not is_atomic and

--- a/kommandir/roles/autotested/defaults/main.yml
+++ b/kommandir/roles/autotested/defaults/main.yml
@@ -60,3 +60,6 @@ docker_autotest:
 
     # Set true to copy in python-bugzilla from cache directory
     enable_bugzilla: true
+
+# If non-empty, pass this string as the parameter to the ``--args`` option
+docker_autotest_mmargs:

--- a/kommandir/roles/autotested/tasks/collect_results.yml
+++ b/kommandir/roles/autotested/tasks/collect_results.yml
@@ -18,7 +18,7 @@
   synchronize:
     mode: pull
     src: "{{ autotest_dest_dir }}/client/results/default/"
-    dest: "{{ workspace }}/results/{{ inventory_hostname }}"
+    dest: "{{ workspace }}/results/{{ inventory_hostname }}/docker_autotest"
   ignore_errors: true
   #no_log: '{{ no_log_synchronize }}'
 

--- a/kommandir/roles/autotested/tasks/parse_prd.yml
+++ b/kommandir/roles/autotested/tasks/parse_prd.yml
@@ -1,0 +1,29 @@
+---
+
+- assert:
+    that:
+      - 'empty is defined'
+      - 'pull_request_description not in empty'
+
+- name: Filter pull_request_description of unacceptable characters/formatting
+  set_fact:
+    docker_autotest_mmargs: >
+          {{ pull_request_description |
+             regex_replace('\s', ' ') |
+             regex_replace('[^ a-zA-Z0-9_\-/\[\]=]', '') }}
+  when: docker_autotest_mmargs|default() in empty
+
+- name: Display value of filtered docker_autotest_mmargs
+  debug:
+    var: "docker_autotest_mmargs"
+
+- name: Parse --args value out of filtered docker_autotest_mmargs
+  set_fact:
+    docker_autotest_mmargs: >
+          {{ pull_request_description |
+             regex_replace('.*\[--args=(.+)\].*', '\1' ) }}
+  when: docker_autotest_mmargs|default() in empty
+
+- name: Display --args value of docker_autotest_mmargs
+  debug:
+    var: "docker_autotest_mmargs"

--- a/kommandir/roles/autotested/tasks/run.yml
+++ b/kommandir/roles/autotested/tasks/run.yml
@@ -2,15 +2,28 @@
 
 - assert:
     that:
-        - 'autotest_docker_path is defined'
-        - 'autotest_dest_dir is defined'
+      - 'empty is defined'
+      - 'autotest_docker_path is defined'
+      - 'autotest_dest_dir is defined'
+
+- include: parse_prd.yml
+  when: pull_request_description | default() not in empty
 
 - block:
 
     - name: Execute Docker autotest
-      shell: "$AUTOTEST_PATH/client/autotest-local {{ autotest_docker_path }}/control &> /dev/null"
+      shell: >
+        $AUTOTEST_PATH/client/autotest-local
+        {{ autotest_docker_path }}/control
+        {{ '--args="$MMARGS"'
+           if docker_autotest_mmargs | default() not in empty
+           else '' }}
+        &> /dev/null
       environment:
         AUTOTEST_PATH: "{{ autotest_dest_dir }}"
+        # Mitigate some risk of accepting external input for executing
+        # inside cloud.  The rest is done by heavily filtering the input
+        MMARGS: "{{ docker_autotest_mmargs }}"
       args:
         chdir: "{{ autotest_docker_path }}"
       register: autotest_execution

--- a/kommandir/roles/failed_peon_junit/defaults/main.yml
+++ b/kommandir/roles/failed_peon_junit/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Location (on kommandir) where peons results.junit would be overwritten by testing
+results_junit_dirpath: "{{ hostvars.kommandir.workspace }}/results/{{ inventory_hostname }}/docker_autotest"

--- a/kommandir/roles/failed_peon_junit/tasks/main.yml
+++ b/kommandir/roles/failed_peon_junit/tasks/main.yml
@@ -11,6 +11,7 @@
           - 'this_role | default() not in empty'
           - 'job_name | default() not in empty'
           - 'hostvars.kommandir.ansible_date_time.date | default() not in empty'
+          - 'results_junit_dirpath | default() not in empty'
 
   - name: Key variables are displayed
     debug:
@@ -19,9 +20,15 @@
 
   when: adept_debug
 
+- name: Path to peon's docker_autotest results.junit exists
+  file:
+    path: "{{ results_junit_dirpath }}"
+    state: directory
+  delegate_to: kommandir
+
 - name: Peon's results.junit file is cooked with failure of upcoming role
   template:
     # peon_up includes this file, need full-path to template
     src: "{{ playbook_dir }}/roles/failed_peon_junit/templates/failed_peon.junit.j2"
-    dest: "{{ hostvars.kommandir.workspace }}/results/{{ inventory_hostname }}/results.junit"
+    dest: "{{ results_junit_dirpath }}/results.junit"
   delegate_to: kommandir

--- a/kommandir/roles/lvm/tasks/main.yml
+++ b/kommandir/roles/lvm/tasks/main.yml
@@ -30,7 +30,7 @@
       enable_repos: "{{ hostvars[inventory_hostname].enable_repos | default([]) }}"
       ansible_distribution: "{{ hostvars[inventory_hostname].ansible_distribution }}"
       all_updated: False
-
+      install_timeout: "{{ hostvars[inventory_hostname].install_timeout | default(60) }}"
   when: not is_atomic|bool
 
 - block:


### PR DESCRIPTION
* Secure passing of external variable values, by filtering them after
parsing.  This prevents a multi-line incoming string value from
corrupting or leaking/overwriting other values.  Previously this was
possible by blindly using 'lineinfile' to set YAML values in
kommandir_vars.yml

* Define new variable ``pull_request_description`` and add
documentation.  Include this value from ``exekutir_vars.yml``
when producing ``kommandir_vars.yml``.

* Define a new variable, ``docker_autotest_mmargs`` for the Autotested
role.  Document this in the role's defaults ``main.yml`` file.
When set, it's contents will be passed to the ``--args`` option
of autotest-local via an environment variable.  The indirect reference
blocks attempts to escape the confines of quoting.

* Add safe-parsing of a magic string from pull_request_description
by first removing white space and unacceptable characters.  When the
filtered result contains ``[--args=<foo>]``, the '<foo>'
value will be extracted and become ``docker_autotest_mmargs``.

Signed-off-by: Chris Evich <cevich@redhat.com>