### PR TITLE
Critical fixes

### DIFF
--- a/.test_openstack_TestDestroy.test_found.json
+++ b/.test_openstack_TestDestroy.test_found.json
@@ -4,16 +4,12 @@
     "response": {
       "servers": [
         {
-          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "id": "deleteme",
           "name": "deleteme"
-        },
-        {
-          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
-          "name": "troublemaker"
         }
       ]
     },
-    "sequence_number": 5,
+    "sequence_number": 0,
     "status_code": 200
   },
   {
@@ -21,12 +17,8 @@
     "response": {
       "servers": [
         {
-          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+          "id": "deleteme",
           "name": "deleteme"
-        },
-        {
-          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
-          "name": "troublemaker"
         }
       ]
     },
@@ -34,75 +26,46 @@
     "status_code": 200
   },
   {
-    "GET": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+    "GET": "http://1.2.3.4/servers/deleteme",
     "response": {
       "server": {
         "OS-EXT-STS:power_state": 1,
         "OS-EXT-STS:vm_state": "active",
-        "addresses": {
-          "network_name": [
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "config_drive": "",
+        "flavor": {
+          "id": "3",
+          "links": [
             {
-              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
-              "OS-EXT-IPS:type": "fixed",
-              "addr": "5.4.3.2",
-              "version": 4
-            },
-            {
-              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:77",
-              "OS-EXT-IPS:type": "floating",
-              "addr": "4.5.6.7",
-              "version": 4
+              "href": "http://1.2.3.4/flavors/3",
+              "rel": "bookmark"
             }
           ]
         },
-        "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
+        "id": "deleteme",
         "name": "deleteme",
         "os-extended-volumes:volumes_attached": [
-            {"id": "4150770f-68b1-4ead-bce2-9f5a0eef8831"}
+          {
+            "id": "19d9b7f9-7d3d-4d56-aecd-6da28fa39f28"
+          }
         ],
+        "progress": 0,
         "status": "ACTIVE"
       }
     },
-    "sequence_number": 12,
-    "status_code": 200
-  },
-  {
-    "DELETE": "http://1.2.3.4/servers/1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
     "sequence_number": 20,
-    "status_code": 204,
-    "response": null
-  },
-  {
-    "GET": "http://1.2.3.4/servers",
-    "response": {
-      "servers": [
-        {
-          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
-          "name": "deleteme"
-        },
-        {
-          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
-          "name": "troublemaker"
-        },
-        {
-          "id": "1d14de48-3ab0-4a0c-8c9f-65f00085d4ec",
-          "name": "deleteme"
-        }
-      ]
-    },
-    "sequence_number": 25,
     "status_code": 200
   },
   {
+    "DELETE": "http://1.2.3.4/servers/deleteme"
+  },
+  {
     "GET": "http://1.2.3.4/servers",
     "response": {
       "servers": [
         {
-          "id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a",
-          "name": "troublemaker"
-        },
-        {
-          "id": "295eb339-d94a-4a12-8c80-7a2b81d473d6",
+          "id": "deleteme",
           "name": "deleteme"
         }
       ]
@@ -111,69 +74,58 @@
     "status_code": 200
   },
   {
-    "GET": "http://1.2.3.4/volumes/4150770f-68b1-4ead-bce2-9f5a0eef8831",
+    "GET": "http://1.2.3.4/servers",
     "response": {
-      "volume": {
-        "attachments": [
-          {"id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a"}
-        ],
-        "id": "4150770f-68b1-4ead-bce2-9f5a0eef8831",
-        "size": 10,
-        "status": "in-use",
-        "name": "deleteme"
-        }
+      "servers": []
     },
-    "sequence_number": 46,
+    "sequence_number": 40,
     "status_code": 200
-  },
-  {
-    "DELETE": "http://1.2.3.4/servers/c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a/os-volume_attachments/4150770f-68b1-4ead-bce2-9f5a0eef8831",
-    "sequence_number": 50,
-    "status_code": 204
-  },
-  {
-    "GET": "http://1.2.3.4/volumes/4150770f-68b1-4ead-bce2-9f5a0eef8831",
-    "response": {
-      "volume": {
-        "attachments": [
-          {"id": "c80f2e0a-09b7-4ad0-ac34-e40a5cfd418a"}
-        ],
-        "id": "4150770f-68b1-4ead-bce2-9f5a0eef8831",
-        "size": 10,
-        "status": "in-use",
-        "name": "deleteme"
-        }
-    },
-    "sequence_number": 54,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/volumes/4150770f-68b1-4ead-bce2-9f5a0eef8831",
-    "response": {
-      "volume": {
-        "attachments": [],
-        "id": "4150770f-68b1-4ead-bce2-9f5a0eef8831",
-        "size": 10,
-        "status": "available",
-        "name": "deleteme"
-        }
-    },
-    "sequence_number": 58,
-    "status_code": 200
-  },
-  {
-    "DELETE": "http://1.2.3.4/volumes/4150770f-68b1-4ead-bce2-9f5a0eef8831",
-    "sequence_number": 59,
-    "status_code": 204
   },
   {
     "GET": "http://1.2.3.4/volumes",
     "response": {
       "volumes": [
-        {"id": "47e8ff25-1465-49c7-a3c5-8c877425d973", "name": "newone"}
+        {
+          "id": "19d9b7f9-7d3d-4d56-aecd-6da28fa39f28",
+          "name": "deleteme"
+        }
       ]
     },
-    "sequence_number": 60,
+    "sequence_number": 50,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/volumes/19d9b7f9-7d3d-4d56-aecd-6da28fa39f28",
+    "response": {
+      "volume": {
+        "attachments": [],
+        "bootable": "false",
+        "consistencygroup_id": null,
+        "description": "Created for deleteme (deleteme)",
+        "id": "19d9b7f9-7d3d-4d56-aecd-6da28fa39f28",
+        "metadata": {
+          "readonly": "False"
+        },
+        "multiattach": false,
+        "name": "deleteme",
+        "size": 20,
+        "status": "available",
+        "volume_type": null
+      }
+    },
+    "sequence_number": 130,
+    "status_code": 200
+  },
+  {
+    "DELETE": "http://1.2.3.4/volumes/19d9b7f9-7d3d-4d56-aecd-6da28fa39f28"
+  },
+  {
+    "GET": "http://1.2.3.4/volumes",
+    "response": {
+      "volumes": [
+      ]
+    },
+    "sequence_number": 202,
     "status_code": 200
   }
 ]

--- a/.test_openstack_TestDiscoverCreate.test_privsize.json
+++ b/.test_openstack_TestDiscoverCreate.test_privsize.json
@@ -1,5 +1,14 @@
 [
   {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
     "GET": "http://1.2.3.4/flavors",
     "response": {
       "flavors": [
@@ -9,7 +18,7 @@
         }
       ]
     },
-    "sequence_number": 20,
+    "sequence_number": 10,
     "status_code": 200
   },
   {
@@ -18,34 +27,32 @@
       "first": "/v2/images?status=active&name=image_name",
       "images": [
         {
-          "id": "the_image_id",
-          "name": "image_name",
-          "status": "active"
+          "id": "5b05bda0-52d5-4d3b-8787-481327d9054c",
+          "size": 551004672,
+          "status": "active",
+          "visibility": "public"
         }
       ],
       "schema": "/v2/schemas/images"
     },
-    "sequence_number": 30,
+    "sequence_number": 20,
     "status_code": 200
   },
   {
     "GET": "http://1.2.3.4/servers",
     "response": {
       "servers": [
-        {
-          "id": "547996c1db08",
-          "name": "anotherone"
-        }
       ]
     },
-    "sequence_number": 32,
+    "sequence_number": 30,
     "status_code": 200
   },
   {
     "POST": "http://1.2.3.4/servers",
     "response": {
       "server": {
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08"
+        "OS-DCF:diskConfig": "MANUAL",
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535"
       }
     },
     "sequence_number": 40,
@@ -56,66 +63,24 @@
     "response": {
       "servers": [
         {
-          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
           "name": "foobar"
-        },
-        {
-          "id": "547996c1db08",
-          "name": "anotherone"
         }
       ]
-    },
-    "sequence_number": 42,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
-    "response": {
-      "server": {
-        "OS-EXT-STS:power_state": 0,
-        "OS-EXT-STS:vm_state": "building",
-        "addresses": {
-          "network_name": []
-        },
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-        "name": "foobar",
-        "os-extended-volumes:volumes_attached": [],
-        "status": "something"
-      }
     },
     "sequence_number": 50,
     "status_code": 200
   },
   {
-    "GET": "http://1.2.3.4/servers",
-    "response": {
-      "servers": [
-        {
-          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-          "name": "foobar"
-        },
-        {
-          "id": "547996c1db08",
-          "name": "anotherone"
-        }
-      ]
-    },
-    "sequence_number": 52,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "GET": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535",
     "response": {
       "server": {
-        "OS-EXT-STS:power_state": 1,
-        "OS-EXT-STS:vm_state": "frobnicating",
-        "addresses": {
-          "network_name": []
-        },
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:task_state": "spawning",
+        "OS-EXT-STS:vm_state": "building",
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
         "name": "foobar",
-        "os-extended-volumes:volumes_attached": [],
-        "status": "something"
+        "status": "BUILD"
       }
     },
     "sequence_number": 60,
@@ -126,143 +91,213 @@
     "response": {
       "servers": [
         {
-          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
           "name": "foobar"
-        },
-        {
-          "id": "547996c1db08",
-          "name": "anotherone"
         }
       ]
-    },
-    "sequence_number": 62,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
-    "response": {
-      "server": {
-        "OS-EXT-STS:power_state": 1,
-        "OS-EXT-STS:vm_state": "active",
-        "addresses": {
-          "network_name": [
-            {
-              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
-              "OS-EXT-IPS:type": "fixed",
-              "addr": "5.4.3.2",
-              "version": 4
-            }
-          ]
-        },
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-        "name": "foobar",
-        "os-extended-volumes:volumes_attached": [],
-        "status": "ACTIVE"
-      }
     },
     "sequence_number": 70,
     "status_code": 200
   },
   {
-    "GET": "http://1.2.3.4/servers",
-    "response": {
-      "servers": [
-        {
-          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-          "name": "foobar"
-        },
-        {
-          "id": "547996c1db08",
-          "name": "anotherone"
-        }
-      ]
-    },
-    "sequence_number": 72,
-    "status_code": 200
-  },
-  {
-    "POST": "http://1.2.3.4/volumes",
-    "response": {
-        "volume": {
-            "id": "12345abcde"
-        }
-    },
-    "sequence_number": 73,
-    "status_code": 202
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
-    "response": {
-      "server": {
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-        "name": "foobar",
-        "os-extended-volumes:volumes_attached": []
-      }
-    },
-    "sequence_number": 74,
-    "status_code": 200
-  },
-  {
-    "POST": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08/os-volume_attachments",
-    "response": {
-      "volumeAttachment": {
-        "device": "/dev/vdb",
-        "id": "12345abcde",
-        "serverId": "102f1788-3b0a-4a37-aecc-547996c1db08",
-        "volumeId": "12345abcde"
-      }
-    },
-    "sequence_number": 76,
-    "status_code": 202
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
-    "response": {
-      "server": {
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-        "name": "foobar",
-        "os-extended-volumes:volumes_attached": [{"id": "12345abcde"}]
-      }
-    },
-    "sequence_number": 77,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/servers",
-    "response": {
-      "servers": [
-        {
-          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
-          "name": "foobar"
-        }
-      ]
-    },
-    "sequence_number": 80,
-    "status_code": 200
-  },
-  {
-    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "GET": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535",
     "response": {
       "server": {
         "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:task_state": null,
         "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": "2017-08-18T20:04:26.000000",
+        "OS-SRV-USG:terminated_at": null,
+        "accessIPv4": "",
+        "accessIPv6": "",
         "addresses": {
           "network_name": [
             {
-              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:56:ec",
               "OS-EXT-IPS:type": "fixed",
               "addr": "5.4.3.2",
               "version": 4
             }
           ]
         },
-        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "config_drive": "",
+        "created": "2017-08-18T20:04:20Z",
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
         "name": "foobar",
         "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
         "status": "ACTIVE"
       }
     },
-    "sequence_number": 90,
+    "sequence_number": 100,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/volumes",
+    "response": {
+      "volume": {
+        "attachments": [],
+        "description": "Created for foobar (f1bc67be-6188-462e-8617-d0a7dc7f2535)",
+        "encrypted": false,
+        "id": "f4d57466-071f-4624-9dbd-96554060d396",
+        "name": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "size": 20,
+        "status": "creating"
+      }
+    },
+    "sequence_number": 110,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/volumes/f4d57466-071f-4624-9dbd-96554060d396",
+    "response": {
+      "volume": {
+        "description": "Created for foobar (f1bc67be-6188-462e-8617-d0a7dc7f2535)",
+        "encrypted": false,
+        "id": "f4d57466-071f-4624-9dbd-96554060d396",
+        "name": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "size": 20,
+        "status": "available",
+        "volume_type": null
+      }
+    },
+    "sequence_number": 120,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:56:ec",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "progress": 0,
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 130,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535/os-volume_attachments",
+    "response": {
+      "volumeAttachment": {
+        "device": "/dev/vdb",
+        "id": "f4d57466-071f-4624-9dbd-96554060d396",
+        "serverId": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "volumeId": "f4d57466-071f-4624-9dbd-96554060d396"
+      }
+    },
+    "sequence_number": 140,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/volumes/f4d57466-071f-4624-9dbd-96554060d396",
+    "response": {
+      "volume": {
+        "attachments": [],
+        "description": "Created for foobar (f1bc67be-6188-462e-8617-d0a7dc7f2535)",
+        "id": "f4d57466-071f-4624-9dbd-96554060d396",
+        "multiattach": false,
+        "name": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "size": 20,
+        "status": "attaching"
+      }
+    },
+    "sequence_number": 150,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:56:ec",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [
+          {
+            "id": "f4d57466-071f-4624-9dbd-96554060d396"
+          }
+        ],
+        "progress": 0,
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 160,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 170,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/f1bc67be-6188-462e-8617-d0a7dc7f2535",
+    "response": {
+      "server": {
+        "OS-DCF:diskConfig": "MANUAL",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:56:ec",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "id": "f1bc67be-6188-462e-8617-d0a7dc7f2535",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [
+          {
+            "id": "f4d57466-071f-4624-9dbd-96554060d396"
+          }
+        ],
+        "progress": 0,
+        "status": "ACTIVE",
+        "updated": "2017-08-18T20:04:26Z"
+      }
+    },
+    "sequence_number": 190,
     "status_code": 200
   }
 ]

--- a/kommandir/roles/autotested/tasks/parse_prd.yml
+++ b/kommandir/roles/autotested/tasks/parse_prd.yml
@@ -28,7 +28,8 @@
     set_fact:
       docker_autotest_mmargs: '{{ result }}'
 
-  when: docker_autotest_mmargs|default() in empty
+  when: docker_autotest_mmargs|default() in empty and
+        pull_request_description | search('(\[--args=(.+)\]){1}')
 
 - name: Display value of parsed buffer
   debug:


### PR DESCRIPTION
Avoid any setting of ``docker_autotest_mmargs`` if the magic string is
not found, or is found more than once.  Without this, the entire
``pull_request_description`` gets passed into ``autotest-local``'s
``--args`` option.

Signed-off-by: Chris Evich <cevich@redhat.com>