### PR TITLE
Update Ansible + Deps for security

### DIFF
--- a/exekutir.xn
+++ b/exekutir.xn
@@ -113,7 +113,7 @@
 - variable:
     name: "ANSIBLE_VAULT_PASSWORD_FILE"
     from_env: "ANSIBLE_VAULT_PASSWORD_FILE"
-    default: ""
+    default: "/dev/null"
 
 # For all contexts, exit non-zero immediatly on failure.
 # Transition summary:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,55 +1,79 @@
 # N/B: Hashes are required here | versions frozen for stability
 
-ansible==2.4.1.0 --hash=sha256:da61afb29cc5bd6bc4737a2da06e673fb6fccc3ae2685130d19ab3a8e404fb6a
+# Fundimental requirement
+ansible==2.7.1 --hash=sha256:e7953472347fcc6dca10839111b576a9f790e00056344f2dcf448e6c452fe939
 
-ansible-lint==3.4.17 --hash=sha256:9cebc110019f52a7dd66cb785d99d43b556f246c3046661b00c7bcfe74a9504d
+# Generally required for yaml parsing
+PyYAML==3.13 --hash=sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf
 
-asn1crypto==0.23.0 --hash=sha256:654b7db3b120e23474e9a1e5e38d268c77e58a9e17d2cb595456c37309846494
-
-bcrypt==3.1.4 --hash=sha256:a005ed6163490988711ff732386b08effcbf8df62ae93dd1e5bda0714fad8afb \
-              --hash=sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20 \
-              --hash=sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832
-
-cffi==1.11.2 --hash=sha256:89829f5cfbcb5ad568a3d61bd23a8e33ad69b488d8f6a385e0097a4c20742a9b \
-             --hash=sha256:d7461ef8671ae40f991384bbc4a6b1b79f4e7175d8052584be44041996f46517 \
-             --hash=sha256:5f96c92d5f5713ccb71e76dfa14cf819c59ecb9778e94bcb541e13e6d96d1ce5
-
-cryptography==2.1.3 --hash=sha256:35eb35340fdc0b772301f9de985db8d732f3c79dbd647d06b9a8e4e111b53950 \
-                    --hash=sha256:1fc1c6ad9f04871399de407a4f0f555adba5c7ec68068fd27d7ceee9e493755c \
-                    --hash=sha256:2d72c8cd1e2be9942052b85b1481c74b2eb36780889696ce66afe602c04b9c67
-
-enum34==1.1.6 --hash=sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a \
-              --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79
-
-idna==2.6 --hash=sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4
-
-ipaddress==1.0.18 --hash=sha256:5d8534c8e185f2d8a1fda1ef73f2c8f4b23264e8e30063feeb9511d492a413e1 \
-                  --hash=sha256:d34cf15d95ce9a734560f7400a8bd2ac2606f378e2a1d0eadbf1c98707e7c74a
-
-Jinja2==2.10 --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd
-
-MarkupSafe==1.0 --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665
-
-paramiko==2.4.0 --hash=sha256:8851e728e8b7590989e68e3936c48ee3ca4dad91d29e3d7ff0305b6c5fc582db
-
-pyasn1==0.3.7 --hash=sha256:16e896433f84575f0636cd9aa8b24659689268a62e00f17235e1fc23c6b00b25
-
-pycparser==2.18 --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226
-
-pycrypto==2.6.1 --hash=sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
-
-PyNaCl==1.2.0 --hash=sha256:8e194ea19c447c4caa94a84316412ad11cfb61f029d408fd4bdc1164ec694578 \
-              --hash=sha256:b83e4232b43a52c8802234d575f992f82c1e9c466acd911983613a3823c4dc4e \
-              --hash=sha256:189410422028e7b0543dee6aca3da026bbd66bbad078143c46c5a3faf2733acb
-
-PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
-
+# Python 2 -> compatibility layer
 six==1.11.0 --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb
 
-virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
+# Fundimental requirement
+virtualenv==16.0.0 --hash=sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669
 
-pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
+# Fundimental requirement
+pip==18.1 --hash=sha256:7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550
 
-virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
+# Dependency of pip/virtualenv
+setuptools==40.5.0 --hash=sha256:e329a5c458c6acb5edc2b5c4ad44280c053ba827dc82fd5e84a83e22bb05460d
 
-pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
+# Dependency of pip/virtualenv
+wheel==0.32.2 --hash=sha256:c93e2d711f5f9841e17f53b0e6c0ff85593f3b416b6eec7a9452041a59a42688
+
+# Ansible dependency for DigitalOcean
+dopy==0.3.7 --hash=sha256:8d1a7a15ef5711220ee9fc3fd489e738bb365cdad042c4f791cd5c16f2dbf9fd
+
+# Ansible dependency
+requests==2.20.0 --hash=sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279
+
+# Ansible dependency
+jinja2==2.10 --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd
+
+# Ansible dependency
+paramiko==2.4.2 --hash=sha256:3c16b2bfb4c0d810b24c40155dbfd113c0521e7e6ee593d704e84b4c658a1f3b
+
+# Ansible dependency
+cryptography==2.3.1 --hash=sha256:31db8febfc768e4b4bd826750a70c79c99ea423f4697d1dab764eb9f9f849519
+
+# Ansible dependency
+idna==2.7 --hash=sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e
+
+# Ansible dependency
+chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+
+# Ansible dependency
+urllib3==1.24 --hash=sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59
+
+# Ansible dependency
+certifi==2018.10.15 --hash=sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c
+
+# Ansible dependency
+MarkupSafe==1.0 --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665
+
+# Ansible dependency
+pynacl==1.3.0 --hash=sha256:0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e
+
+# Ansible dependency
+pyasn1==0.4.4 --hash=sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca
+
+# Ansible dependency
+bcrypt==3.1.4 --hash=sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20
+
+# Ansible dependency
+enum34==1.1.6 --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79
+
+# Ansible dependency
+cffi==1.11.5 --hash=sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f
+
+# Ansible dependency
+asn1crypto==0.24.0 --hash=sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87
+
+# Ansible dependency
+ipaddress==1.0.22 --hash=sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794
+
+# Ansible dependency
+pycparser==2.19 --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
+
+--only-binary ':all:'
+--no-binary 'ansible,MarkupSafe,pycparser,pycrypto,PyYAML,dopy'

--- a/venv-cmd.sh
+++ b/venv-cmd.sh
@@ -80,14 +80,15 @@ echo
         # pip may not support --cache-dir, force it's location into $WORKSPACE the ugly-way
         OLD_HOME="$HOME"
         export HOME="$WORKSPACE"
-        pip install --force-reinstall --upgrade pip==9.0.1
-        # Undo --cache-dir workaround
-        export HOME="$OLD_HOME"
+        pip install --disable-pip-version-check --force-reinstall --upgrade \
+            pip==18.1 setuptools==40.5.0 wheel==0.32.2
         # Install fixed, trusted, hashed versions of all requirements (including pip and virtualenv)
         pip --cache-dir="$PIPCACHE" install --force-reinstall --require-hashes \
             --requirement "$SCRIPT_DIR/requirements.txt"
         # Setup trusted virtualenv using hashed packages from requirements.txt
         ./.venvbootstrap/bin/virtualenv --no-site-packages --python=python2.7 "./$VENV_DIRNAME"
+        # Undo --cache-dir workaround
+        export HOME="$OLD_HOME"
         # Exit untrusted virtualenv
         deactivate
         rm -rf ./.venvbootstrap  # No longer needed


### PR DESCRIPTION
Ansible 2.7 does not appear to include breaking changes for older use
cases.  However, many of Ansible's dependencies have had security-fixes, and
so deserve updating.

Signed-off-by: Chris Evich <cevich@redhat.com>